### PR TITLE
Possible fix for Jacoco not supporting cross Maven module tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
     token:
       secure: HSdBT8AaylyTtZHq73L98HmMXvuUQ7exj4/ApZnu6z1k5q7mymphDjOuMrXkWL4Tp6+2HAXpqlKnckrjx2G7h/3O5N/hf1FQMrnbQK8jGeKtG8X0yuRg/H2CZwv4aVORlrvpt86FnwivuC3TaOhcecbcs5b/f1kORn6aSmyV6KAV1rV6uNzZPHXNdcC+YK98RpTHxzh2kjW9/IHMByn14Jli27/GLW4ks5Uc7oyC1vGSIHuEqAcGPPoXVUxsfOYEakPsdyKHCk71HQ1OdukZahkNnjdSOaJNKjBJFlcgg4umYUuRD4cRVV9rDSOqwuYGwktpU7tLveggM9Ihyv/WEuOmplms8pjZH5aY6FI8/UHh83tybQfSfyE+HAMnJIyVZ6iVLEh2GDGfd45WRmqR25BSsKhU/F45nyahVzEP3jMZQ9fXOg4cYzEbdD8Df3zOjw6Q4vUqno7MbieH3QEDYuX++4GrzILFwSX6j+4zIRGayZyZRrQuQw1GSvf9ro+T2G9B5XS4xJcDFQ2GJ7+CgVHwBjC+e9zGkzv6ipx8oI1BO3vcaX7vWvgtUGhzlvMArPdZAvGfM89XkGKpShMFqZvrJXlCqqHiWF4J4f9Qtly6//Er5Rf3vSC53BJUIvd+R1BeVg3/Ynb/blwLJHRTwiKsqHrwJOGH+DdC3+Scois=
 script:
-  - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar
+  - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent verify sonar:sonar
 before_deploy:
   - openssl aes-256-cbc -K $encrypted_1cc2137e332d_key -iv $encrypted_1cc2137e332d_iv -in codesigning.asc.enc -out codesigning.asc -d
   - gpg --fast-import codesigning.asc

--- a/jacoco-report-aggregate/pom.xml
+++ b/jacoco-report-aggregate/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.dotwebstack.framework</groupId>
+    <artifactId>dotwebstack-framework</artifactId>
+    <version>0.0.9-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>dotwebstack-jacoco-report-aggregate</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.dotwebstack.framework</groupId>
+      <artifactId>dotwebstack-backend-elasticsearch</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.dotwebstack.framework</groupId>
+      <artifactId>dotwebstack-backend-sparql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.dotwebstack.framework</groupId>
+      <artifactId>dotwebstack-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.dotwebstack.framework</groupId>
+      <artifactId>dotwebstack-frontend-http</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.dotwebstack.framework</groupId>
+      <artifactId>dotwebstack-frontend-ld</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.dotwebstack.framework</groupId>
+      <artifactId>dotwebstack-frontend-openapi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.dotwebstack.framework</groupId>
+      <artifactId>dotwebstack-test</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.dotwebstack.framework</groupId>
+      <artifactId>dotwebstack-integration-test</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>report-aggregate</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report-aggregate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>
+  

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
     <module>frontend</module>
     <module>test</module>
     <module>integration-test</module>
+    <module>jacoco-report-aggregate</module>
   </modules>
 
   <dependencyManagement>
@@ -115,6 +116,11 @@
       <dependency>
         <groupId>org.dotwebstack.framework</groupId>
         <artifactId>dotwebstack-test</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.dotwebstack.framework</groupId>
+        <artifactId>dotwebstack-integration-test</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Please change the script part in the Travis config into:

"script": [
    "mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent **verify** sonar:sonar"
]