### PR TITLE
GRID-2189: fix op StringSchemaMapper; possible fix for Javadoc errors and SonarQube issues

### DIFF
--- a/core/src/main/java/org/dotwebstack/framework/AbstractResourceProvider.java
+++ b/core/src/main/java/org/dotwebstack/framework/AbstractResourceProvider.java
@@ -95,6 +95,7 @@ public abstract class AbstractResourceProvider<R> implements ResourceProvider<R>
 
   protected abstract R createResource(Model model, IRI identifier);
 
+  @SuppressWarnings("unused")
   protected void finalizeResource(Model model, R resource) {}
 
   protected Optional<String> getObjectString(Model model, IRI subject, IRI predicate) {

--- a/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/backend/Rdf4jRepositoryBackend.java
+++ b/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/backend/Rdf4jRepositoryBackend.java
@@ -21,6 +21,8 @@ public class Rdf4jRepositoryBackend extends AbstractRdf4jBackend {
   /**
    * Initialise a new RDF4J backend using the repository passed as argument. Queries will include
    * inferred statements and all contexts.
+   * 
+   * @param repository The back-end repository.
    */
   public Rdf4jRepositoryBackend(@NonNull Repository repository) {
     this(repository, true);

--- a/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/AbstractSubjectFilterSchemaMapper.java
+++ b/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/AbstractSubjectFilterSchemaMapper.java
@@ -9,6 +9,7 @@ import org.dotwebstack.framework.frontend.openapi.entity.GraphEntityContext;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
@@ -29,7 +30,7 @@ abstract class AbstractSubjectFilterSchemaMapper<S extends Property, T>
    *         {@link OpenApiSpecificationExtensions#SUBJECT_FILTER} vendor extension defined. Please
    *         call {@link #hasSubjectFilterVendorExtension(Property)} before calling this method.
    */
-  protected final Set<Resource> filterSubjects(@NonNull Property property,
+  protected final Set<Resource> getSubjects(@NonNull Property property,
       @NonNull GraphEntityContext graphEntityContext) {
     if (!hasSubjectFilterVendorExtension(property)) {
       throw new IllegalStateException(String.format(
@@ -58,6 +59,38 @@ abstract class AbstractSubjectFilterSchemaMapper<S extends Property, T>
     Model filteredModel = graphEntityContext.getModel().filter(null, predicateIri, objectIri);
 
     return filteredModel.subjects();
+  }
+
+  /**
+   * @return Applies the subject filter and returns the single subject, or {@code null} if no
+   *         subject can be found.
+   * @throws IllegalStateException If the property does not have the
+   *         {@link OpenApiSpecificationExtensions#SUBJECT_FILTER} vendor extension defined. Please
+   *         call {@link #hasSubjectFilterVendorExtension(Property)} before calling this method.
+   * @throws SchemaMapperRuntimeException If no predicate and object have been defined for the
+   *         subject filter.
+   * @throws SchemaMapperRuntimeException If the property is required, and no subject can be found.
+   * @throws SchemaMapperRuntimeException If more than one subject has been found.
+   */
+  protected final Value getSubject(@NonNull Property property,
+      @NonNull GraphEntityContext graphEntityContext) {
+    Set<Resource> subjects = getSubjects(property, graphEntityContext);
+
+    if (subjects.isEmpty()) {
+      if (property.getRequired()) {
+        throw new SchemaMapperRuntimeException(
+            "Subject filter for a required object property yielded no result.");
+      }
+
+      return null;
+    }
+
+    if (subjects.size() > 1) {
+      throw new SchemaMapperRuntimeException(
+          "More entrypoint subjects found. Only one is required.");
+    }
+
+    return subjects.iterator().next();
   }
 
 }

--- a/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/ArraySchemaMapper.java
+++ b/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/ArraySchemaMapper.java
@@ -31,7 +31,7 @@ public class ArraySchemaMapper extends AbstractSubjectFilterSchemaMapper<ArrayPr
     ImmutableList.Builder<Object> builder = ImmutableList.builder();
 
     if (hasSubjectFilterVendorExtension(property)) {
-      Set<Resource> subjects = filterSubjects(property, graphEntityContext);
+      Set<Resource> subjects = getSubjects(property, graphEntityContext);
 
       subjects.forEach(subject -> {
         ValueContext subjectContext = valueContext.toBuilder().value(subject).build();

--- a/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/ObjectSchemaMapper.java
+++ b/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/ObjectSchemaMapper.java
@@ -13,7 +13,6 @@ import lombok.NonNull;
 import org.dotwebstack.framework.frontend.openapi.OpenApiSpecificationExtensions;
 import org.dotwebstack.framework.frontend.openapi.entity.GraphEntityContext;
 import org.dotwebstack.framework.frontend.openapi.entity.LdPathExecutor;
-import org.dotwebstack.framework.frontend.openapi.entity.schema.ValueContext.ValueContextBuilder;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
@@ -38,7 +37,7 @@ class ObjectSchemaMapper extends AbstractSubjectFilterSchemaMapper<ObjectPropert
 
   private static ValueContext populateValueContextWithVendorExtensions(@NonNull Property property,
       @NonNull ValueContext valueContext) {
-    ValueContextBuilder builder = valueContext.toBuilder();
+    ValueContext.ValueContextBuilder builder = valueContext.toBuilder();
 
     if (hasVendorExtension(property,
         OpenApiSpecificationExtensions.EXCLUDE_PROPERTIES_WHEN_EMPTY_OR_NULL)) {
@@ -57,7 +56,7 @@ class ObjectSchemaMapper extends AbstractSubjectFilterSchemaMapper<ObjectPropert
 
   private Object handleProperty(ObjectProperty property, GraphEntityContext graphEntityContext,
       ValueContext valueContext, SchemaMapperAdapter schemaMapperAdapter) {
-    ValueContextBuilder builder = valueContext.toBuilder();
+    ValueContext.ValueContextBuilder builder = valueContext.toBuilder();
 
     if (hasSubjectFilterVendorExtension(property)) {
       Set<Resource> subjects = filterSubjects(property, graphEntityContext);

--- a/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/ObjectSchemaMapper.java
+++ b/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/ObjectSchemaMapper.java
@@ -14,7 +14,6 @@ import org.dotwebstack.framework.frontend.openapi.OpenApiSpecificationExtensions
 import org.dotwebstack.framework.frontend.openapi.entity.GraphEntityContext;
 import org.dotwebstack.framework.frontend.openapi.entity.LdPathExecutor;
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Value;
 import org.springframework.stereotype.Service;
 
@@ -59,23 +58,13 @@ class ObjectSchemaMapper extends AbstractSubjectFilterSchemaMapper<ObjectPropert
     ValueContext.ValueContextBuilder builder = valueContext.toBuilder();
 
     if (hasSubjectFilterVendorExtension(property)) {
-      Set<Resource> subjects = filterSubjects(property, graphEntityContext);
+      Value value = getSubject(property, graphEntityContext);
 
-      if (subjects.isEmpty()) {
-        if (property.getRequired()) {
-          throw new SchemaMapperRuntimeException(
-              "Subject filter for a required object property yielded no result.");
-        }
-
+      if (value == null) {
         return null;
       }
 
-      if (subjects.size() > 1) {
-        throw new SchemaMapperRuntimeException(
-            "More entrypoint subjects found. Only one is required.");
-      }
-
-      builder.value(subjects.iterator().next());
+      builder.value(value);
     }
 
     ValueContext newValueContext = builder.build();

--- a/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/ResponseSchemaMapper.java
+++ b/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/ResponseSchemaMapper.java
@@ -6,7 +6,7 @@ import java.util.Set;
 import lombok.NonNull;
 import org.dotwebstack.framework.frontend.openapi.entity.GraphEntityContext;
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Value;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -24,23 +24,13 @@ class ResponseSchemaMapper extends AbstractSubjectFilterSchemaMapper<ResponsePro
     ValueContext.ValueContextBuilder builder = valueContext.toBuilder();
 
     if (hasSubjectFilterVendorExtension(property)) {
-      Set<Resource> subjects = filterSubjects(property, graphEntityContext);
+      Value value = getSubject(property, graphEntityContext);
 
-      if (subjects.isEmpty()) {
-        if (property.getRequired()) {
-          throw new SchemaMapperRuntimeException(
-              "Subject filter for a required object property yielded no result.");
-        }
-
+      if (value == null) {
         return null;
       }
 
-      if (subjects.size() > 1) {
-        throw new SchemaMapperRuntimeException(
-            "More entrypoint subjects found. Only one is required.");
-      }
-
-      builder.value(subjects.iterator().next());
+      builder.value(value);
     }
 
     return schemaMapperAdapter.mapGraphValue(property.getSchema(), graphEntityContext,

--- a/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/ResponseSchemaMapper.java
+++ b/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/ResponseSchemaMapper.java
@@ -5,7 +5,6 @@ import io.swagger.models.properties.Property;
 import java.util.Set;
 import lombok.NonNull;
 import org.dotwebstack.framework.frontend.openapi.entity.GraphEntityContext;
-import org.dotwebstack.framework.frontend.openapi.entity.schema.ValueContext.ValueContextBuilder;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Resource;
 import org.springframework.stereotype.Service;
@@ -22,7 +21,7 @@ class ResponseSchemaMapper extends AbstractSubjectFilterSchemaMapper<ResponsePro
   public Object mapGraphValue(@NonNull ResponseProperty property,
       @NonNull GraphEntityContext graphEntityContext, @NonNull ValueContext valueContext,
       @NonNull SchemaMapperAdapter schemaMapperAdapter) {
-    ValueContextBuilder builder = valueContext.toBuilder();
+    ValueContext.ValueContextBuilder builder = valueContext.toBuilder();
 
     if (hasSubjectFilterVendorExtension(property)) {
       Set<Resource> subjects = filterSubjects(property, graphEntityContext);

--- a/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/StringSchemaMapper.java
+++ b/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/StringSchemaMapper.java
@@ -45,14 +45,13 @@ class StringSchemaMapper extends AbstractSchemaMapper<StringProperty, String> {
       return handleConstantValueVendorExtension(property);
     }
 
-    if (valueContext.getValue() != null && isSupportedLiteral(valueContext.getValue())) {
+    if (valueContext.getValue() != null) {
       return valueContext.getValue().stringValue();
     } else if (property.getRequired()) {
       throw new SchemaMapperRuntimeException("No result for required property.");
     }
 
     return null;
-
   }
 
   /**

--- a/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/ldpath/SortByPropertyFunction.java
+++ b/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/ldpath/SortByPropertyFunction.java
@@ -32,7 +32,6 @@ import org.slf4j.LoggerFactory;
  * "number" or "date"; direction can be one of "asc" or "desc"</li>
  *
  * </ul>
- * <p/>
  * Author: Nathan van Dalen
  */
 public class SortByPropertyFunction<N> extends SelectorFunction<N> {

--- a/frontend/openapi/src/test/java/org/dotwebstack/framework/frontend/openapi/entity/LdPathExecutorTest.java
+++ b/frontend/openapi/src/test/java/org/dotwebstack/framework/frontend/openapi/entity/LdPathExecutorTest.java
@@ -1,0 +1,51 @@
+package org.dotwebstack.framework.frontend.openapi.entity;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collection;
+import org.dotwebstack.framework.test.DBEERPEDIA;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.util.ModelBuilder;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LdPathExecutorTest {
+
+  @Mock
+  private GraphEntityContext entityContextMock;
+
+  @Before
+  public void setUp() {}
+
+  @Test
+  public void ldPathQuery_ReturnsResult_ForQuery() {
+
+    // Arrange
+    when(entityContextMock.getLdPathNamespaces()).thenReturn(
+        ImmutableMap.of("beer", "http://dbeerpedia.org#"));
+
+    Model model = new ModelBuilder().subject(DBEERPEDIA.BROUWTOREN).add(RDF.TYPE,
+        DBEERPEDIA.BREWERY_TYPE).add(DBEERPEDIA.NAME, DBEERPEDIA.BROUWTOREN_NAME).subject(
+            DBEERPEDIA.MAXIMUS).add(RDF.TYPE, DBEERPEDIA.BREWERY_TYPE).add(DBEERPEDIA.NAME,
+                DBEERPEDIA.MAXIMUS_NAME).build();
+    when(entityContextMock.getModel()).thenReturn(model);
+
+    LdPathExecutor executor = new LdPathExecutor(entityContextMock);
+
+    // Act
+    Collection<Value> result = executor.ldPathQuery(DBEERPEDIA.BROUWTOREN, "beer:Name");
+
+    // Assert
+    assertThat(result, contains(DBEERPEDIA.BROUWTOREN_NAME));
+  }
+
+}

--- a/frontend/openapi/src/test/java/org/dotwebstack/framework/frontend/openapi/entity/schema/AbstractSubjectFilterSchemaMapperTest.java
+++ b/frontend/openapi/src/test/java/org/dotwebstack/framework/frontend/openapi/entity/schema/AbstractSubjectFilterSchemaMapperTest.java
@@ -56,7 +56,7 @@ public class AbstractSubjectFilterSchemaMapperTest {
                 "http://www.test.nl#obj3"))));
     when(propertyMock.getVendorExtensions()).thenReturn(vendorExtensions);
     // Act
-    Set<Resource> results = mapper.filterSubjects(propertyMock, graphEntityContextMock);
+    Set<Resource> results = mapper.getSubjects(propertyMock, graphEntityContextMock);
     // Assert
     assertThat(results, hasSize(is(0)));
   }
@@ -77,7 +77,7 @@ public class AbstractSubjectFilterSchemaMapperTest {
                 "http://www.test.nl#obj1"))));
     when(propertyMock.getVendorExtensions()).thenReturn(vendorExtensions);
     // Act
-    Set<Resource> results = mapper.filterSubjects(propertyMock, graphEntityContextMock);
+    Set<Resource> results = mapper.getSubjects(propertyMock, graphEntityContextMock);
     // Assert
     assertThat(results, hasSize(is(2)));
   }
@@ -93,7 +93,7 @@ public class AbstractSubjectFilterSchemaMapperTest {
                 "http://www.test.nl#is"))));
     when(propertyMock.getVendorExtensions()).thenReturn(vendorExtensions);
     // Act
-    mapper.filterSubjects(propertyMock, graphEntityContextMock);
+    mapper.getSubjects(propertyMock, graphEntityContextMock);
   }
 
   @Test

--- a/frontend/openapi/src/test/java/org/dotwebstack/framework/frontend/openapi/entity/schema/StringSchemaMapperTest.java
+++ b/frontend/openapi/src/test/java/org/dotwebstack/framework/frontend/openapi/entity/schema/StringSchemaMapperTest.java
@@ -1,18 +1,27 @@
 package org.dotwebstack.framework.frontend.openapi.entity.schema;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.swagger.models.properties.IntegerProperty;
 import io.swagger.models.properties.StringProperty;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 import org.dotwebstack.framework.frontend.openapi.OpenApiSpecificationExtensions;
 import org.dotwebstack.framework.frontend.openapi.entity.GraphEntityContext;
+import org.dotwebstack.framework.frontend.openapi.entity.LdPathExecutor;
 import org.dotwebstack.framework.test.DBEERPEDIA;
+import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,28 +36,32 @@ public class StringSchemaMapperTest {
   @Rule
   public ExpectedException expectedException = ExpectedException.none();
 
+  private static final ValueFactory VALUE_FACTORY = SimpleValueFactory.getInstance();
+
   @Mock
-  private Value contextMock;
+  private GraphEntityContext entityContextMock;
+  @Mock
+  private LdPathExecutor ldPathExecutorMock;
+  @Mock
+  private Value subjectMock;
 
-  private GraphEntityContext entityBuilderContextMock;
-
-  private SchemaMapperAdapter schemaMapperAdapter;
-
-  private StringSchemaMapper schemaMapper;
-  private StringProperty stringProperty;
+  private SchemaMapperAdapter mapperAdapter;
+  private StringProperty property;
+  private StringSchemaMapper mapper;
 
   @Before
   public void setUp() {
-    entityBuilderContextMock = mock(GraphEntityContext.class);
-    schemaMapper = new StringSchemaMapper();
-    stringProperty = new StringProperty();
-    schemaMapperAdapter = new SchemaMapperAdapter(Arrays.asList(schemaMapper));
+    mapper = new StringSchemaMapper();
+    property = new StringProperty();
+    mapperAdapter = new SchemaMapperAdapter(Arrays.asList(mapper));
+
+    when(entityContextMock.getLdPathExecutor()).thenReturn(ldPathExecutorMock);
   }
 
   @Test
   public void mapTupleValue_ReturnValue_ForLiterals() {
     // Arrange & Act
-    String result = schemaMapper.mapTupleValue(stringProperty,
+    String result = mapper.mapTupleValue(property,
         ValueContext.builder().value(DBEERPEDIA.BROUWTOREN_NAME).build());
 
     // Assert
@@ -58,7 +71,7 @@ public class StringSchemaMapperTest {
   @Test
   public void supports_ReturnsTrue_ForStringProperty() {
     // Arrange & Act
-    Boolean supported = schemaMapper.supports(stringProperty);
+    Boolean supported = mapper.supports(property);
 
     // Assert
     assertThat(supported, equalTo(true));
@@ -67,20 +80,10 @@ public class StringSchemaMapperTest {
   @Test
   public void supports_ReturnsTrue_ForNonStringProperty() {
     // Arrange & Act
-    Boolean supported = schemaMapper.supports(new IntegerProperty());
+    Boolean supported = mapper.supports(new IntegerProperty());
 
     // Assert
     assertThat(supported, equalTo(false));
-  }
-
-  @Test
-  public void mapGraphValue_ReturnsNull_WhenNoVendorExtensionHasBeenDefined() {
-    // Act
-    Object result = schemaMapperAdapter.mapGraphValue(stringProperty, entityBuilderContextMock,
-        ValueContext.builder().value(contextMock).build(), schemaMapperAdapter);
-
-    // Assert
-    assertThat(result, nullValue());
   }
 
   @Test
@@ -89,12 +92,12 @@ public class StringSchemaMapperTest {
     expectExceptionAboutMultipleVendorExtensions();
 
     // Arrange
-    stringProperty.setVendorExtensions(ImmutableMap.of(OpenApiSpecificationExtensions.LDPATH, "",
+    property.setVendorExtensions(ImmutableMap.of(OpenApiSpecificationExtensions.LDPATH, "",
         OpenApiSpecificationExtensions.RELATIVE_LINK, ImmutableMap.of()));
 
     // Act
-    schemaMapperAdapter.mapGraphValue(stringProperty, entityBuilderContextMock,
-        ValueContext.builder().value(contextMock).build(), schemaMapperAdapter);
+    mapperAdapter.mapGraphValue(property, entityContextMock, ValueContext.builder().build(),
+        mapperAdapter);
   }
 
   @Test
@@ -103,12 +106,12 @@ public class StringSchemaMapperTest {
     expectExceptionAboutMultipleVendorExtensions();
 
     // Arrange
-    stringProperty.setVendorExtensions(ImmutableMap.of(OpenApiSpecificationExtensions.LDPATH,
+    property.setVendorExtensions(ImmutableMap.of(OpenApiSpecificationExtensions.LDPATH,
         ImmutableMap.of(), OpenApiSpecificationExtensions.CONSTANT_VALUE, ImmutableMap.of()));
 
     // Act
-    schemaMapperAdapter.mapGraphValue(stringProperty, entityBuilderContextMock,
-        ValueContext.builder().value(contextMock).build(), schemaMapperAdapter);
+    mapperAdapter.mapGraphValue(property, entityContextMock, ValueContext.builder().build(),
+        mapperAdapter);
   }
 
   @Test
@@ -117,12 +120,12 @@ public class StringSchemaMapperTest {
     expectExceptionAboutMultipleVendorExtensions();
 
     // Arrange
-    stringProperty.setVendorExtensions(ImmutableMap.of(OpenApiSpecificationExtensions.RELATIVE_LINK,
+    property.setVendorExtensions(ImmutableMap.of(OpenApiSpecificationExtensions.RELATIVE_LINK,
         ImmutableMap.of(), OpenApiSpecificationExtensions.CONSTANT_VALUE, ImmutableMap.of()));
 
     // Act
-    schemaMapperAdapter.mapGraphValue(stringProperty, entityBuilderContextMock,
-        ValueContext.builder().value(contextMock).build(), schemaMapperAdapter);
+    mapperAdapter.mapGraphValue(property, entityContextMock, ValueContext.builder().build(),
+        mapperAdapter);
   }
 
   @Test
@@ -131,13 +134,184 @@ public class StringSchemaMapperTest {
     expectExceptionAboutMultipleVendorExtensions();
 
     // Arrange
-    stringProperty.setVendorExtensions(ImmutableMap.of(OpenApiSpecificationExtensions.RELATIVE_LINK,
+    property.setVendorExtensions(ImmutableMap.of(OpenApiSpecificationExtensions.RELATIVE_LINK,
         ImmutableMap.of(), OpenApiSpecificationExtensions.CONSTANT_VALUE, ImmutableMap.of(),
         OpenApiSpecificationExtensions.LDPATH, ImmutableMap.of()));
 
     // Act
-    schemaMapperAdapter.mapGraphValue(stringProperty, entityBuilderContextMock,
-        ValueContext.builder().value(contextMock).build(), schemaMapperAdapter);
+    mapperAdapter.mapGraphValue(property, entityContextMock, ValueContext.builder().build(),
+        mapperAdapter);
+  }
+
+  @Test
+  public void mapGraphValue_ReturnsNull_ForNullValue() {
+    // Act
+    Object result = mapperAdapter.mapGraphValue(property, entityContextMock,
+        ValueContext.builder().value(null).build(), mapperAdapter);
+
+    // Assert
+    assertThat(result, nullValue());
+  }
+
+  @Test
+  public void mapGraphValue_ReturnsStringValue_ForNonLiteral() {
+    // Act
+    Object result = mapperAdapter.mapGraphValue(property, entityContextMock,
+        ValueContext.builder().value(VALUE_FACTORY.createIRI("http://foo")).build(), mapperAdapter);
+
+    // Assert
+    assertThat(result, is("http://foo"));
+  }
+
+  @Test
+  public void mapGraphValue_ThrowsException_ForNullValueAndRequiredProperty() {
+    // Assert
+    expectedException.expect(SchemaMapperRuntimeException.class);
+    expectedException.expectMessage("No result for required property");
+
+    // Arrange
+    property.setRequired(true);
+
+    // Act
+    mapperAdapter.mapGraphValue(property, entityContextMock,
+        ValueContext.builder().value(null).build(), mapperAdapter);
+  }
+
+  @Test
+  public void mapGraphValue_ReturnsStringValue_ForXmlSchemaStringLiteral() {
+    // Arrange
+    Literal xmlSchemaStringLiteral = VALUE_FACTORY.createLiteral("foo", XMLSchema.STRING);
+
+    // Act
+    String result = mapper.mapGraphValue(property, entityContextMock,
+        ValueContext.builder().value(xmlSchemaStringLiteral).build(), mapperAdapter);
+
+    // Assert
+    assertThat(result, is("foo"));
+  }
+
+  @Test
+  public void mapGraphValue_ReturnsStringValue_ForRdfLangStringLiteral() {
+    // Arrange
+    Literal rdfLangStringLiteral = VALUE_FACTORY.createLiteral("foo", "nl");
+
+    // Act
+    String result = mapper.mapGraphValue(property, entityContextMock,
+        ValueContext.builder().value(rdfLangStringLiteral).build(), mapperAdapter);
+
+    // Assert
+    assertThat(result, is("foo"));
+  }
+
+  @Test
+  public void mapGraphValue_ReturnsStringValue_ForLdPath() {
+    // Arrange
+    property.setVendorExtensions(ImmutableMap.of(OpenApiSpecificationExtensions.LDPATH, "ld-path"));
+
+    Literal literal = VALUE_FACTORY.createLiteral("foo", XMLSchema.STRING);
+
+    when(ldPathExecutorMock.ldPathQuery(subjectMock, "ld-path")).thenReturn(
+        ImmutableList.of(literal));
+
+    // Act
+    String result = mapper.mapGraphValue(property, entityContextMock,
+        ValueContext.builder().value(subjectMock).build(), mapperAdapter);
+
+    // Assert
+    assertThat(result, is("foo"));
+  }
+
+  @Test
+  public void mapGraphValue_ReturnsNull_ForNullLdPath() {
+    // Arrange
+    property.setVendorExtensions(nullableMapOf(OpenApiSpecificationExtensions.LDPATH, null));
+
+    // Act
+    String result = mapper.mapGraphValue(property, entityContextMock,
+        ValueContext.builder().value(subjectMock).build(), mapperAdapter);
+
+    // Assert
+    assertThat(result, nullValue());
+  }
+
+  @Test
+  public void mapGraphValue_ThrowsException_ForNullLdPathAndRequiredProperty() {
+    // Assert
+    expectedException.expect(SchemaMapperRuntimeException.class);
+    expectedException.expectMessage(
+        "String property has 'x-dotwebstack-ldpath' vendor extension that is null, "
+            + "but the property is required");
+
+    // Arrange
+    property.setVendorExtensions(nullableMapOf(OpenApiSpecificationExtensions.LDPATH, null));
+    property.setRequired(true);
+
+    // Act
+    mapper.mapGraphValue(property, entityContextMock,
+        ValueContext.builder().value(subjectMock).build(), mapperAdapter);
+  }
+
+  @Test
+  public void mapGraphValue_ReturnsNull_ForLdPathAndEmptyResult() {
+    // Arrange
+    property.setVendorExtensions(ImmutableMap.of(OpenApiSpecificationExtensions.LDPATH, "ld-path"));
+
+    when(ldPathExecutorMock.ldPathQuery(subjectMock, "ld-path")).thenReturn(ImmutableList.of());
+
+    // Act
+    String result = mapper.mapGraphValue(property, entityContextMock,
+        ValueContext.builder().value(subjectMock).build(), mapperAdapter);
+
+    // Assert
+    assertThat(result, nullValue());
+  }
+
+  @Test
+  public void mapGraphValue_ReturnsNull_ForLdPathEmptyResultAndRequiredProperty() {
+    // Assert
+    expectedException.expect(SchemaMapperRuntimeException.class);
+    expectedException.expectMessage("No results for LDPath query 'ld-path' for required property");
+
+    // Arrange
+    property.setVendorExtensions(nullableMapOf(OpenApiSpecificationExtensions.LDPATH, "ld-path"));
+    property.setRequired(true);
+
+    when(ldPathExecutorMock.ldPathQuery(subjectMock, "ld-path")).thenReturn(ImmutableList.of());
+
+    // Act
+    mapper.mapGraphValue(property, entityContextMock,
+        ValueContext.builder().value(subjectMock).build(), mapperAdapter);
+  }
+
+  @Test
+  public void mapGraphValue_ReturnsNull_ForLdPathMultipleResultsAndRequiredProperty() {
+    // Assert
+    expectedException.expect(SchemaMapperRuntimeException.class);
+    expectedException.expectMessage(
+        "LDPath query 'ld-path' yielded multiple results (2) for a property, "
+            + "which requires a single result.");
+
+    // Arrange
+    property.setVendorExtensions(nullableMapOf(OpenApiSpecificationExtensions.LDPATH, "ld-path"));
+    property.setRequired(true);
+
+    Literal foo = VALUE_FACTORY.createLiteral("foo", XMLSchema.STRING);
+    Literal bar = VALUE_FACTORY.createLiteral("bar", XMLSchema.STRING);
+
+    when(ldPathExecutorMock.ldPathQuery(subjectMock, "ld-path")).thenReturn(
+        ImmutableList.of(foo, bar));
+
+    // Act
+    mapper.mapGraphValue(property, entityContextMock,
+        ValueContext.builder().value(subjectMock).build(), mapperAdapter);
+  }
+
+  private static Map<String, Object> nullableMapOf(String key, Object val) {
+    Map<String, Object> result = new HashMap<>();
+
+    result.put(key, val);
+
+    return result;
   }
 
   private void expectExceptionAboutMultipleVendorExtensions() {


### PR DESCRIPTION
Ha Joost,

Kan jij https://github.com/dotwebstack/dotwebstack-framework/pull/93 reviewen en mergen met master?

Overview:

- StringSchemaMapper now returns stringValue() for every Value.
Minimale fix in de mapper, ik heb met name de testdekking op de mapper flink uitgebreid (ook testdekking niet gerelateerd aan de change)
- Fix op Java warnings / errors;
Of dit de fix is gaan we zien als we een release maken. Bij vervolg warnings maken we nieuwe task aan;
- Fix duplicate code Sonar
Of dit het issue oplost gaan we zien met de Sonar run.
  
Dank!