### PR TITLE
GRID-3079: Dependency updates

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.freemarker</groupId>
       <artifactId>freemarker</artifactId>
-      <version>2.3.26-incubating</version><!--$NO-MVN-MAN-VER$-->
+      <version>2.3.28</version><!--$NO-MVN-MAN-VER$-->
     </dependency>
 
     <dependency>

--- a/frontend/openapi/pom.xml
+++ b/frontend/openapi/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.atlassian.oai</groupId>
       <artifactId>swagger-request-validator-core</artifactId>
-      <version>1.3.2</version>
+      <version>1.4.2</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <spring.boot.version>1.5.4.RELEASE</spring.boot.version>
-    <rdf4j.version>2.2.4</rdf4j.version>
+    <rdf4j.version>2.3.2</rdf4j.version>
     <slf4j.version>1.7.25</slf4j.version>
     <mockito.version>2.18.3</mockito.version>
   </properties>
@@ -201,7 +201,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>23.0</version>
+        <version>25.0-jre</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <spring.boot.version>1.5.4.RELEASE</spring.boot.version>
-    <rdf4j.version>2.3.2</rdf4j.version>
+    <rdf4j.version>2.2.4</rdf4j.version>
     <slf4j.version>1.7.25</slf4j.version>
     <mockito.version>2.18.3</mockito.version>
   </properties>


### PR DESCRIPTION
Did not update the following dependencies because they break the build:
- rdf4j (2.2.4 --> 2.3.2)
- topbraid.shacl (1.0.1 --> 1.1.0)
- jena-arq (3.4.0 --> 3.7.0)