### PR TITLE
Bugfix voor Persistencestep query evaluator

### DIFF
--- a/backend/sparql/src/main/java/org/dotwebstack/framework/backend/sparql/QueryEvaluator.java
+++ b/backend/sparql/src/main/java/org/dotwebstack/framework/backend/sparql/QueryEvaluator.java
@@ -77,6 +77,8 @@ public class QueryEvaluator {
           String.format("Data could not be added into graph: %s", e.getMessage()), e);
     } catch (Exception ex) {
       LOG.debug("Data could not be added into graph: {} \n {}", ex.getMessage(), ex);
+      throw new BackendException(
+          String.format("Data could not be added into graph: %s", ex.getMessage()), ex);
     }
   }
 

--- a/backend/sparql/src/main/java/org/dotwebstack/framework/backend/sparql/QueryEvaluator.java
+++ b/backend/sparql/src/main/java/org/dotwebstack/framework/backend/sparql/QueryEvaluator.java
@@ -159,21 +159,21 @@ public class QueryEvaluator {
 
   private String getSubjectString(Statement statement) {
     if (statement.getSubject() instanceof IRI || statement.getSubject() instanceof MemIRI) {
-      return " <" + statement.getSubject() + "> ";
+      return " <" + statement.getSubject() + ">";
     }
     return " " + statement.getSubject();
   }
 
   private String getPredicateString(Statement statement) {
     if (statement.getPredicate() instanceof IRI || statement.getPredicate() instanceof MemIRI) {
-      return " <" + statement.getPredicate() + "> ";
+      return " <" + statement.getPredicate() + ">";
     }
     return " " + statement.getPredicate();
   }
 
   private String getObjectString(Statement statement) {
     if (statement.getObject() instanceof IRI || statement.getObject() instanceof MemIRI) {
-      return " <" + statement.getObject() + "> ";
+      return " <" + statement.getObject() + ">";
     }
     return " " + statement.getObject();
   }

--- a/backend/sparql/src/main/java/org/dotwebstack/framework/backend/sparql/QueryEvaluator.java
+++ b/backend/sparql/src/main/java/org/dotwebstack/framework/backend/sparql/QueryEvaluator.java
@@ -72,13 +72,13 @@ public class QueryEvaluator {
         addMultipleStatements(repositoryConnection, model, targetGraph);
       }
     } catch (RDF4JException e) {
-      LOG.debug("Data could not be added into graph: {}", e.getMessage());
+      LOG.debug("Data could not be added to graph: {}", e.getMessage());
       throw new BackendException(
-          String.format("Data could not be added into graph: %s", e.getMessage()), e);
+          String.format("Data could not be added to graph: %s", e.getMessage()), e);
     } catch (Exception ex) {
       LOG.debug("Data could not be added into graph: {} \n {}", ex.getMessage(), ex);
       throw new BackendException(
-          String.format("Data could not be added into graph: %s", ex.getMessage()), ex);
+          String.format("Data could not be added to graph: %s", ex.getMessage()), ex);
     }
   }
 

--- a/backend/sparql/src/main/java/org/dotwebstack/framework/backend/sparql/QueryEvaluator.java
+++ b/backend/sparql/src/main/java/org/dotwebstack/framework/backend/sparql/QueryEvaluator.java
@@ -18,6 +18,7 @@ import org.eclipse.rdf4j.query.QueryLanguage;
 import org.eclipse.rdf4j.query.TupleQuery;
 import org.eclipse.rdf4j.query.Update;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.sail.memory.model.MemIRI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -155,24 +156,24 @@ public class QueryEvaluator {
   }
 
   private String getSubjectString(Statement statement) {
-    if (statement.getSubject() instanceof BNode) {
-      return " " + statement.getSubject();
+    if (statement.getSubject() instanceof IRI || statement.getSubject() instanceof MemIRI) {
+      return " <" + statement.getSubject() + "> ";
     }
-    return " <" + statement.getSubject() + "> ";
+    return " " + statement.getSubject();
   }
 
   private String getPredicateString(Statement statement) {
-    if (statement.getPredicate() instanceof BNode) {
-      return " " + statement.getPredicate();
+    if (statement.getPredicate() instanceof IRI || statement.getPredicate() instanceof MemIRI) {
+      return " <" + statement.getPredicate() + "> ";
     }
-    return " <" + statement.getPredicate() + "> ";
+    return " " + statement.getPredicate();
   }
 
   private String getObjectString(Statement statement) {
-    if (statement.getObject() instanceof BNode) {
-      return " " + statement.getObject();
+    if (statement.getObject() instanceof IRI || statement.getObject() instanceof MemIRI) {
+      return " <" + statement.getObject() + "> ";
     }
-    return " <" + statement.getObject() + "> ";
+    return " " + statement.getObject();
   }
 
   private String getGraphString(Resource graphName) {

--- a/backend/sparql/src/main/java/org/dotwebstack/framework/backend/sparql/persistencestep/PersistenceInsertIntoGraphStepExecutor.java
+++ b/backend/sparql/src/main/java/org/dotwebstack/framework/backend/sparql/persistencestep/PersistenceInsertIntoGraphStepExecutor.java
@@ -8,6 +8,7 @@ import org.dotwebstack.framework.backend.sparql.QueryEvaluator;
 import org.dotwebstack.framework.backend.sparql.SparqlBackend;
 import org.dotwebstack.framework.param.Parameter;
 import org.dotwebstack.framework.transaction.flow.step.AbstractStepExecutor;
+import org.dotwebstack.framework.transaction.flow.step.StepFailureException;
 import org.dotwebstack.framework.transaction.flow.step.persistence.PersistenceStep;
 import org.eclipse.rdf4j.model.Model;
 import org.slf4j.Logger;
@@ -57,6 +58,8 @@ public class PersistenceInsertIntoGraphStepExecutor extends AbstractStepExecutor
       }
     } catch (Exception ex) {
       LOG.debug("Get error {} for persistence step {}", ex, step.getIdentifier());
+      throw new StepFailureException(
+          String.format("Get an error for persistence step {%s}", step.getIdentifier()));
     }
   }
 

--- a/backend/sparql/src/main/java/org/dotwebstack/framework/backend/sparql/persistencestep/PersistenceInsertIntoGraphStepExecutor.java
+++ b/backend/sparql/src/main/java/org/dotwebstack/framework/backend/sparql/persistencestep/PersistenceInsertIntoGraphStepExecutor.java
@@ -57,9 +57,9 @@ public class PersistenceInsertIntoGraphStepExecutor extends AbstractStepExecutor
             backend.getIdentifier(), applicationProperties.getSystemGraph(), step.getIdentifier());
       }
     } catch (Exception ex) {
-      LOG.debug("Get error {} for persistence step {}", ex, step.getIdentifier());
+      LOG.debug("Got error {} for persistence step {}", ex, step.getIdentifier());
       throw new StepFailureException(
-          String.format("Get an error for persistence step {%s}", step.getIdentifier()));
+          String.format("Got an error for persistence step {%s}", step.getIdentifier()));
     }
   }
 

--- a/backend/sparql/src/test/java/org/dotwebstack/framework/backend/sparql/QueryEvaluatorTest.java
+++ b/backend/sparql/src/test/java/org/dotwebstack/framework/backend/sparql/QueryEvaluatorTest.java
@@ -271,8 +271,8 @@ public class QueryEvaluatorTest {
     insertQueryBuilder.append(
         "GRAPH <" + applicationProperties.getSystemGraph().stringValue() + "> {\n");
     insertQueryBuilder.append(" " + bNode);
-    insertQueryBuilder.append(" <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ");
-    insertQueryBuilder.append(" <http://dotwebstack.org/def/elmo#Endpoint> ");
+    insertQueryBuilder.append(" <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>");
+    insertQueryBuilder.append(" <http://dotwebstack.org/def/elmo#Endpoint>");
     insertQueryBuilder.append(".\n");
     insertQueryBuilder.append("}\n};\n");
     final String query = insertQueryBuilder.toString();
@@ -298,8 +298,8 @@ public class QueryEvaluatorTest {
     insertQueryBuilder.append(
         "GRAPH <" + applicationProperties.getSystemGraph().stringValue() + "> {\n");
     insertQueryBuilder.append(" " + bNode);
-    insertQueryBuilder.append(" <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ");
-    insertQueryBuilder.append(" <http://dotwebstack.org/def/elmo#Endpoint> ");
+    insertQueryBuilder.append(" <http://www.w3.org/1999/02/22-rdf-syntax-ns#type>");
+    insertQueryBuilder.append(" <http://dotwebstack.org/def/elmo#Endpoint>");
     insertQueryBuilder.append(".\n");
     insertQueryBuilder.append("}\n};\n");
     final String query = insertQueryBuilder.toString();
@@ -327,7 +327,7 @@ public class QueryEvaluatorTest {
         "GRAPH <" + applicationProperties.getSystemGraph().stringValue() + "> {\n");
     insertQueryBuilder.append(" " + bNode);
     insertQueryBuilder.append(" <" + RDFS.LABEL + "> ");
-    insertQueryBuilder.append(" \"Blaat\"");
+    insertQueryBuilder.append("\"Blaat\"");
     insertQueryBuilder.append(".\n");
     insertQueryBuilder.append("}\n};\n");
     final String query = insertQueryBuilder.toString();

--- a/backend/sparql/src/test/java/org/dotwebstack/framework/backend/sparql/QueryEvaluatorTest.java
+++ b/backend/sparql/src/test/java/org/dotwebstack/framework/backend/sparql/QueryEvaluatorTest.java
@@ -23,6 +23,7 @@ import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.query.BooleanQuery;
 import org.eclipse.rdf4j.query.GraphQuery;
 import org.eclipse.rdf4j.query.GraphQueryResult;
@@ -299,6 +300,34 @@ public class QueryEvaluatorTest {
     insertQueryBuilder.append(" " + bNode);
     insertQueryBuilder.append(" <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> ");
     insertQueryBuilder.append(" <http://dotwebstack.org/def/elmo#Endpoint> ");
+    insertQueryBuilder.append(".\n");
+    insertQueryBuilder.append("}\n};\n");
+    final String query = insertQueryBuilder.toString();
+
+    when(repositoryConnection.prepareGraphQuery(any(), any())).thenReturn(mock(GraphQuery.class));
+
+    // Act
+    queryEvaluator.add(repositoryConnection, model, applicationProperties.getSystemGraph());
+
+    // Assert
+    verify(repositoryConnection, times(1)).prepareGraphQuery(QueryLanguage.SPARQL, query);
+  }
+
+  @Test
+  public void add_InsertQuery_WithString() {
+    // Arrange
+    Model model = new LinkedHashModel();
+    final BNode bNode = valueFactory.createBNode();
+    final IRI context = valueFactory.createIRI("http://dotwebstack.org/configuration/Theatre");
+    model.add(valueFactory.createStatement(bNode, RDFS.LABEL, valueFactory.createLiteral("Blaat"),
+        context));
+    StringBuilder insertQueryBuilder = new StringBuilder();
+    insertQueryBuilder.append("INSERT {\n");
+    insertQueryBuilder.append(
+        "GRAPH <" + applicationProperties.getSystemGraph().stringValue() + "> {\n");
+    insertQueryBuilder.append(" " + bNode);
+    insertQueryBuilder.append(" <" + RDFS.LABEL + "> ");
+    insertQueryBuilder.append(" \"Blaat\"");
     insertQueryBuilder.append(".\n");
     insertQueryBuilder.append("}\n};\n");
     final String query = insertQueryBuilder.toString();

--- a/backend/sparql/src/test/java/org/dotwebstack/framework/backend/sparql/QueryEvaluatorTest.java
+++ b/backend/sparql/src/test/java/org/dotwebstack/framework/backend/sparql/QueryEvaluatorTest.java
@@ -2,6 +2,7 @@ package org.dotwebstack.framework.backend.sparql;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -275,6 +276,8 @@ public class QueryEvaluatorTest {
     insertQueryBuilder.append("}\n};\n");
     final String query = insertQueryBuilder.toString();
 
+    when(repositoryConnection.prepareGraphQuery(any(), any())).thenReturn(mock(GraphQuery.class));
+
     // Act
     queryEvaluator.add(repositoryConnection, model, applicationProperties.getSystemGraph());
 
@@ -299,6 +302,8 @@ public class QueryEvaluatorTest {
     insertQueryBuilder.append(".\n");
     insertQueryBuilder.append("}\n};\n");
     final String query = insertQueryBuilder.toString();
+
+    when(repositoryConnection.prepareGraphQuery(any(), any())).thenReturn(mock(GraphQuery.class));
 
     // Act
     queryEvaluator.add(repositoryConnection, model, applicationProperties.getSystemGraph());

--- a/integration-test/src/test/java/org/dotwebstack/framework/frontend/ld/LdIntegrationTest.java
+++ b/integration-test/src/test/java/org/dotwebstack/framework/frontend/ld/LdIntegrationTest.java
@@ -219,7 +219,7 @@ public class LdIntegrationTest {
   }
 
   @Test
-  public void post_WhenBackendFails_ThroughLdApi() {
+  public void post_WhenBackendFails_ThroughBadRequest() {
     // Arrange
     String rdf = "<?xml version=\"1.0\"?>\n" + "\n" + "<rdf:RDF\n"
         + "xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"\n"

--- a/integration-test/src/test/java/org/dotwebstack/framework/frontend/ld/LdIntegrationTest.java
+++ b/integration-test/src/test/java/org/dotwebstack/framework/frontend/ld/LdIntegrationTest.java
@@ -234,7 +234,7 @@ public class LdIntegrationTest {
         target.path("/dbp/ld/v1/add-concept").request().post(Entity.entity(rdf, MediaTypes.RDFXML));
 
     // Assert
-    assertThat(response.getStatus(), equalTo(Status.INTERNAL_SERVER_ERROR.getStatusCode()));
+    assertThat(response.getStatus(), equalTo(Status.BAD_REQUEST.getStatusCode()));
   }
 
 }


### PR DESCRIPTION
In de QueryEvaluator was een bug, die een INSERT query niet netjes omzette.
Als voorbeeld:
"INSERT {
  GRAPH <http://dotwebstack.org/configuration/Theatre> {
 _:node1cgj9r8k0x1 <http://www.w3.org/2000/01/rdf-schema#label>  <"Blaat"> .
}
};"
Maar <"Blaat"> is niet correct, het moet zonder de <> zijn.
Dus zo moet de output eruit kom te zien:
"INSERT {
GRAPH <http://dotwebstack.org/configuration/Theatre> {
 _:node1cgj9r8k0x1 <http://www.w3.org/2000/01/rdf-schema#label>  "Blaat" .
}
};"