### PR TITLE
GRID-3118: Lower swagger-parser dependency 

### DIFF
--- a/frontend/openapi/pom.xml
+++ b/frontend/openapi/pom.xml
@@ -28,8 +28,8 @@
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-parser</artifactId>
-      <version>1.0.39</version>
-      <!--higher version will fail the test for this release-->
+      <version>1.0.34</version>
+      <!--higher version will fail the integrationtest for this release-->
     </dependency>
     <dependency>
       <groupId>com.atlassian.oai</groupId>


### PR DESCRIPTION
1.0.39 caused issues in one of the projects using DWS.