### PR TITLE
GRID-3521: Fix long schema mapper

### DIFF
--- a/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/AbstractSchemaMapper.java
+++ b/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/AbstractSchemaMapper.java
@@ -139,9 +139,10 @@ public abstract class AbstractSchemaMapper<S extends Schema, T> implements Schem
    * @throws SchemaMapperRuntimeException if none of these or multiple of these vendor extensions
    *         are encountered.
    */
-  void validateVendorExtensions(Schema schema, Set<String> supportedExtensions) {
-    if (schema.getExtensions().keySet().stream().filter(
-        supportedExtensions::contains).count() != 1) {
+  private void validateVendorExtensions(Schema schema, Set<String> supportedExtensions) {
+    if (schema.getExtensions().keySet().stream() //
+        .filter(supportedExtensions::contains) //
+        .count() != 1) {
 
       String message = schema.getClass().getSimpleName() + " object must have one of: "
           + supportedExtensions.toString().replaceAll("[\\[\\]]", "'").replaceAll(", ", "', '")

--- a/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/AbstractSchemaMapper.java
+++ b/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/AbstractSchemaMapper.java
@@ -139,9 +139,9 @@ public abstract class AbstractSchemaMapper<S extends Schema, T> implements Schem
    * @throws SchemaMapperRuntimeException if none of these or multiple of these vendor extensions
    *         are encountered.
    */
-  private void validateVendorExtensions(Schema schema, Set<String> supportedExtensions) {
-    if (schema.getExtensions().keySet().stream().filter(supportedExtensions::contains)//
-        .count() != 1) {
+  void validateVendorExtensions(Schema schema, Set<String> supportedExtensions) {
+    if (schema.getExtensions().keySet().stream().filter(
+        supportedExtensions::contains).count() != 1) {
 
       String message = schema.getClass().getSimpleName() + " object must have one of: "
           + supportedExtensions.toString().replaceAll("[\\[\\]]", "'").replaceAll(", ", "', '")

--- a/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/LongSchemaMapper.java
+++ b/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/LongSchemaMapper.java
@@ -4,11 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import java.util.Set;
-import javax.validation.constraints.NotNull;
-import lombok.NonNull;
 import org.dotwebstack.framework.frontend.openapi.OpenApiSpecificationExtensions;
-import org.dotwebstack.framework.frontend.openapi.entity.GraphEntity;
-import org.dotwebstack.framework.frontend.openapi.entity.TupleEntity;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
@@ -24,27 +20,6 @@ public class LongSchemaMapper extends AbstractSchemaMapper<IntegerSchema, Long> 
   @Override
   protected Set<String> getSupportedVendorExtensions() {
     return SUPPORTED_VENDOR_EXTENSIONS;
-  }
-
-  @Override
-  public Long mapTupleValue(@NonNull IntegerSchema schema, @NonNull TupleEntity entity,
-      @NonNull ValueContext valueContext) {
-    return SchemaMapperUtils.castLiteralValue(valueContext.getValue()).longValue();
-  }
-
-  @Override
-  public Long mapGraphValue(@NonNull IntegerSchema schema, boolean required,
-      @NonNull GraphEntity graphEntity, @NotNull ValueContext valueContext,
-      @NonNull SchemaMapperAdapter schemaMapperAdapter) {
-    validateVendorExtensions(schema, SUPPORTED_VENDOR_EXTENSIONS);
-
-    if (SUPPORTED_VENDOR_EXTENSIONS.contains(OpenApiSpecificationExtensions.LDPATH)) {
-      return handleLdPathVendorExtension(schema, required, valueContext, graphEntity);
-    }
-    if (SUPPORTED_VENDOR_EXTENSIONS.contains(OpenApiSpecificationExtensions.CONSTANT_VALUE)) {
-      return handleConstantValueVendorExtension(schema, required);
-    }
-    return SchemaMapperUtils.castLiteralValue(valueContext.getValue()).longValue();
   }
 
   @Override

--- a/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/LongSchemaMapper.java
+++ b/frontend/openapi/src/main/java/org/dotwebstack/framework/frontend/openapi/entity/schema/LongSchemaMapper.java
@@ -36,6 +36,14 @@ public class LongSchemaMapper extends AbstractSchemaMapper<IntegerSchema, Long> 
   public Long mapGraphValue(@NonNull IntegerSchema schema, boolean required,
       @NonNull GraphEntity graphEntity, @NotNull ValueContext valueContext,
       @NonNull SchemaMapperAdapter schemaMapperAdapter) {
+    validateVendorExtensions(schema, SUPPORTED_VENDOR_EXTENSIONS);
+
+    if (SUPPORTED_VENDOR_EXTENSIONS.contains(OpenApiSpecificationExtensions.LDPATH)) {
+      return handleLdPathVendorExtension(schema, required, valueContext, graphEntity);
+    }
+    if (SUPPORTED_VENDOR_EXTENSIONS.contains(OpenApiSpecificationExtensions.CONSTANT_VALUE)) {
+      return handleConstantValueVendorExtension(schema, required);
+    }
     return SchemaMapperUtils.castLiteralValue(valueContext.getValue()).longValue();
   }
 

--- a/frontend/openapi/src/test/java/org/dotwebstack/framework/frontend/openapi/entity/schema/LongSchemaMapperTest.java
+++ b/frontend/openapi/src/test/java/org/dotwebstack/framework/frontend/openapi/entity/schema/LongSchemaMapperTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableList;
 import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.StringSchema;
+import java.util.Collections;
 import org.dotwebstack.framework.frontend.openapi.OpenApiSpecificationExtensions;
 import org.dotwebstack.framework.frontend.openapi.entity.GraphEntity;
 import org.dotwebstack.framework.frontend.openapi.entity.LdPathExecutor;
@@ -54,6 +55,9 @@ public class LongSchemaMapperTest {
   public void setUp() {
     longSchemaMapper = new LongSchemaMapper();
     longProperty = new IntegerSchema().format("int64");
+
+    when(graphEntityMock.getLdPathExecutor()).thenReturn(ldPathExecutorMock);
+    schemaMapperAdapter = new SchemaMapperAdapter(Collections.singletonList(longSchemaMapper));
   }
 
   @Test
@@ -119,7 +123,7 @@ public class LongSchemaMapperTest {
         ValueContext.builder().value(valueMock).build(), schemaMapperAdapter);
 
     // Assert
-    assertThat(result, is(VALUE_1.floatValue()));
+    assertThat(result, is(VALUE_1.longValue()));
   }
 
   @Test

--- a/frontend/openapi/src/test/java/org/dotwebstack/framework/frontend/openapi/entity/schema/LongSchemaMapperTest.java
+++ b/frontend/openapi/src/test/java/org/dotwebstack/framework/frontend/openapi/entity/schema/LongSchemaMapperTest.java
@@ -1,12 +1,24 @@
 package org.dotwebstack.framework.frontend.openapi.entity.schema;
 
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
+import com.google.common.collect.ImmutableList;
 import io.swagger.v3.oas.models.media.IntegerSchema;
 import io.swagger.v3.oas.models.media.StringSchema;
+import org.dotwebstack.framework.frontend.openapi.OpenApiSpecificationExtensions;
+import org.dotwebstack.framework.frontend.openapi.entity.GraphEntity;
+import org.dotwebstack.framework.frontend.openapi.entity.LdPathExecutor;
 import org.dotwebstack.framework.frontend.openapi.entity.TupleEntity;
 import org.dotwebstack.framework.test.DBEERPEDIA;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -17,13 +29,24 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class LongSchemaMapperTest {
+  
+  private static final String DUMMY_EXPR = "dummyExpr()";
+  private static final Literal VALUE_1 = SimpleValueFactory.getInstance().createLiteral(12345L);
+  private static final IRI VALUE_2 = SimpleValueFactory.getInstance().createIRI("http://foo");
 
   @Rule
   public final ExpectedException thrown = ExpectedException.none();
 
   @Mock
+  private GraphEntity graphEntityMock;
+  @Mock
+  private Value valueMock;
+  @Mock
+  private LdPathExecutor ldPathExecutorMock;
+  @Mock
   private TupleEntity tupleEntityMock;
 
+  private SchemaMapperAdapter schemaMapperAdapter;
   private LongSchemaMapper longSchemaMapper;
   private IntegerSchema longProperty;
 
@@ -82,5 +105,37 @@ public class LongSchemaMapperTest {
 
     // Assert
     assertThat(supported, equalTo(false));
+  }
+
+  @Test
+  public void mapGraphValue_ReturnsValue_ForLdPath() {
+    // Arrange
+    longProperty.addExtension(OpenApiSpecificationExtensions.LDPATH, DUMMY_EXPR);
+    when(ldPathExecutorMock.ldPathQuery(valueMock, DUMMY_EXPR)).thenReturn(
+        ImmutableList.of(VALUE_1));
+ 
+    // Act
+    Long result = (Long) schemaMapperAdapter.mapGraphValue(longProperty, false, graphEntityMock,
+        ValueContext.builder().value(valueMock).build(), schemaMapperAdapter);
+
+    // Assert
+    assertThat(result, is(VALUE_1.floatValue()));
+  }
+
+  @Test
+  public void mapGraphValue_ThrowsException_ForUnsupportedType() {
+    // Assert
+    thrown.expect(SchemaMapperRuntimeException.class);
+    thrown.expectMessage(String.format(
+        "LDPathQuery '%s' yielded a value which is not a literal of supported type", DUMMY_EXPR));
+
+    // Arrange
+    longProperty.addExtension(OpenApiSpecificationExtensions.LDPATH, DUMMY_EXPR);
+    when(ldPathExecutorMock.ldPathQuery(eq(valueMock), anyString())).thenReturn(
+        ImmutableList.of(VALUE_2));
+
+    // Act
+    schemaMapperAdapter.mapGraphValue(longProperty, false, graphEntityMock,
+        ValueContext.builder().value(valueMock).build(), schemaMapperAdapter);
   }
 }


### PR DESCRIPTION
This fix is for an older story and I thought it had been picked up in another branch, but that doesn't seem tot be the case. The fix is still relevant, since now long values aren't mapped properly.
