### PR TITLE
Improved literal conversion

### DIFF
--- a/backend/rdf4j/src/main/java/org/dotwebstack/framework/backend/rdf4j/ValueUtils.java
+++ b/backend/rdf4j/src/main/java/org/dotwebstack/framework/backend/rdf4j/ValueUtils.java
@@ -28,9 +28,7 @@ public final class ValueUtils {
     Literal literal = (Literal) value;
     IRI dataType = literal.getDatatype();
 
-    if (XMLSchema.STRING.equals(dataType)) {
-      return literal.stringValue();
-    } else if (XMLSchema.BOOLEAN.equals(dataType)) {
+    if (XMLSchema.BOOLEAN.equals(dataType)) {
       return literal.booleanValue();
     } else if (XMLSchema.INT.equals(dataType)) {
       return literal.intValue();
@@ -50,7 +48,7 @@ public final class ValueUtils {
       return literal.byteValue();
     }
 
-    return literal;
+    return literal.stringValue();
   }
 
   public static IRI findRequiredPropertyIri(Model model, Resource subject, IRI predicate) {

--- a/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/ValueUtilsTest.java
+++ b/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/ValueUtilsTest.java
@@ -55,12 +55,13 @@ class ValueUtilsTest {
   }
 
   @Test
-  void convertValue_ReturnsLiteral_ForNonBuiltInScalars() {
+  void convertValue_ReturnsString_ForNonBuiltInScalars() {
     // Act
-    Object result = ValueUtils.convertValue(VF.createLiteral(new Date()));
+    Literal literal = VF.createLiteral(new Date());
+    Object result = ValueUtils.convertValue(literal);
 
     // Assert
-    assertThat(result, is(instanceOf(Literal.class)));
+    assertThat(result, is(equalTo(literal.stringValue())));
   }
 
   @Test

--- a/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/query/ValueFetcherTest.java
+++ b/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/query/ValueFetcherTest.java
@@ -43,7 +43,7 @@ class ValueFetcherTest {
         .build());
     Model model = new ModelBuilder()
         .add(BREWERY_EXAMPLE_1, BREWERY_IDENTIFIER_PATH,
-                BREWERY_IDENTIFIER_EXAMPLE_1)
+            BREWERY_IDENTIFIER_EXAMPLE_1)
         .build();
     when(environment.getFieldType()).thenReturn(Scalars.GraphQLID);
     when(environment.getSource()).thenReturn(new QuerySolution(model, BREWERY_EXAMPLE_1));
@@ -56,7 +56,7 @@ class ValueFetcherTest {
   }
 
   @Test
-  void get_ReturnsLiteral_ForForeignScalarField() {
+  void get_ReturnsString_ForForeignScalarField() {
     // Arrange
     ValueFetcher valueFetcher = new ValueFetcher(PropertyShape.builder()
         .name(BREWERY_FOUNDED_FIELD)
@@ -73,7 +73,7 @@ class ValueFetcherTest {
     Object result = valueFetcher.get(environment);
 
     // Assert
-    assertThat(result, is(equalTo(BREWERY_FOUNDED_EXAMPLE_1)));
+    assertThat(result, is(equalTo(BREWERY_FOUNDED_EXAMPLE_1.stringValue())));
   }
 
   @Test

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,10 +24,6 @@
       <artifactId>graphql-java</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.rdf4j</groupId>
-      <artifactId>rdf4j-model</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-jexl3</artifactId>
     </dependency>

--- a/core/src/main/java/org/dotwebstack/framework/core/scalars/DateCoercing.java
+++ b/core/src/main/java/org/dotwebstack/framework/core/scalars/DateCoercing.java
@@ -14,17 +14,13 @@ class DateCoercing implements Coercing<LocalDate, LocalDate> {
       return (LocalDate) value;
     }
 
-    String dateStr;
-
-    if (value instanceof String) {
-      dateStr = (String) value;
-    } else {
+    if (!(value instanceof String)) {
       throw new CoercingSerializeException(
           String.format("Unable to parse date string from '%s' type.", value.getClass().getName()));
     }
 
     try {
-      return LocalDate.parse(dateStr);
+      return LocalDate.parse((String) value);
     } catch (DateTimeParseException e) {
       throw new CoercingSerializeException("Parsing date string failed.", e);
     }

--- a/core/src/main/java/org/dotwebstack/framework/core/scalars/DateCoercing.java
+++ b/core/src/main/java/org/dotwebstack/framework/core/scalars/DateCoercing.java
@@ -5,8 +5,6 @@ import graphql.schema.CoercingSerializeException;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import lombok.NonNull;
-import org.eclipse.rdf4j.model.Literal;
-import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 
 class DateCoercing implements Coercing<LocalDate, LocalDate> {
 
@@ -20,8 +18,6 @@ class DateCoercing implements Coercing<LocalDate, LocalDate> {
 
     if (value instanceof String) {
       dateStr = (String) value;
-    } else if (value instanceof Literal && XMLSchema.DATE.equals(((Literal) value).getDatatype())) {
-      dateStr = ((Literal) value).stringValue();
     } else {
       throw new CoercingSerializeException(
           String.format("Unable to parse date string from '%s' type.", value.getClass().getName()));

--- a/core/src/main/java/org/dotwebstack/framework/core/scalars/DateTimeCoercing.java
+++ b/core/src/main/java/org/dotwebstack/framework/core/scalars/DateTimeCoercing.java
@@ -5,8 +5,6 @@ import graphql.schema.CoercingSerializeException;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
 import lombok.NonNull;
-import org.eclipse.rdf4j.model.Literal;
-import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 
 class DateTimeCoercing implements Coercing<ZonedDateTime, ZonedDateTime> {
 
@@ -20,9 +18,6 @@ class DateTimeCoercing implements Coercing<ZonedDateTime, ZonedDateTime> {
 
     if (value instanceof String) {
       dateTimeStr = (String) value;
-    } else if (value instanceof Literal && XMLSchema.DATETIME
-        .equals(((Literal) value).getDatatype())) {
-      dateTimeStr = ((Literal) value).stringValue();
     } else {
       throw new CoercingSerializeException(String
           .format("Unable to parse date-time string from '%s' type.", value.getClass().getName()));

--- a/core/src/main/java/org/dotwebstack/framework/core/scalars/DateTimeCoercing.java
+++ b/core/src/main/java/org/dotwebstack/framework/core/scalars/DateTimeCoercing.java
@@ -14,17 +14,13 @@ class DateTimeCoercing implements Coercing<ZonedDateTime, ZonedDateTime> {
       return (ZonedDateTime) value;
     }
 
-    String dateTimeStr;
-
-    if (value instanceof String) {
-      dateTimeStr = (String) value;
-    } else {
+    if (!(value instanceof String)) {
       throw new CoercingSerializeException(String
           .format("Unable to parse date-time string from '%s' type.", value.getClass().getName()));
     }
 
     try {
-      return ZonedDateTime.parse(dateTimeStr);
+      return ZonedDateTime.parse((String) value);
     } catch (DateTimeParseException e) {
       throw new CoercingSerializeException("Parsing date-time string failed.", e);
     }

--- a/core/src/test/java/org/dotwebstack/framework/core/scalars/DateCoercingTest.java
+++ b/core/src/test/java/org/dotwebstack/framework/core/scalars/DateCoercingTest.java
@@ -8,28 +8,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import graphql.schema.CoercingSerializeException;
 import java.time.LocalDate;
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
-import org.eclipse.rdf4j.model.Literal;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.junit.jupiter.api.Test;
 
 class DateCoercingTest {
 
-  private static final ValueFactory VF = SimpleValueFactory.getInstance();
-
-  private static final DatatypeFactory datatypeFactory;
-
   private final DateCoercing coercing = new DateCoercing();
-
-  static {
-    try {
-      datatypeFactory = DatatypeFactory.newInstance();
-    } catch (DatatypeConfigurationException e) {
-      throw new IllegalStateException(e);
-    }
-  }
 
   @Test
   void serialize_ReturnsDate_ForDate() {
@@ -57,26 +40,6 @@ class DateCoercingTest {
     // Act / Assert
     assertThrows(CoercingSerializeException.class, () ->
         coercing.serialize("foo"));
-  }
-
-  @Test
-  void serialize_ReturnsDate_ForValidLiteral() {
-    // Arrange
-    Literal dateLiteral = VF.createLiteral(
-        datatypeFactory.newXMLGregorianCalendar("2018-05-30"));
-
-    // Act
-    LocalDate date = coercing.serialize(dateLiteral);
-
-    // Assert
-    assertThat(date, is(equalTo(LocalDate.of(2018, 5, 30))));
-  }
-
-  @Test
-  void serialize_ReturnsDate_ForInvalidLiteral() {
-    // Act / Assert
-    assertThrows(CoercingSerializeException.class, () ->
-        coercing.serialize(VF.createLiteral("foo")));
   }
 
   @Test

--- a/core/src/test/java/org/dotwebstack/framework/core/scalars/DateTimeCoercingTest.java
+++ b/core/src/test/java/org/dotwebstack/framework/core/scalars/DateTimeCoercingTest.java
@@ -9,28 +9,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import graphql.schema.CoercingSerializeException;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
-import org.eclipse.rdf4j.model.Literal;
-import org.eclipse.rdf4j.model.ValueFactory;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.junit.jupiter.api.Test;
 
 class DateTimeCoercingTest {
 
-  private static final ValueFactory VF = SimpleValueFactory.getInstance();
-
-  private static final DatatypeFactory datatypeFactory;
-
   private final DateTimeCoercing coercing = new DateTimeCoercing();
-
-  static {
-    try {
-      datatypeFactory = DatatypeFactory.newInstance();
-    } catch (DatatypeConfigurationException e) {
-      throw new IllegalStateException(e);
-    }
-  }
 
   @Test
   void serialize_ReturnsDateTime_ForDateTime() {
@@ -59,27 +42,6 @@ class DateTimeCoercingTest {
     // Act / Assert
     assertThrows(CoercingSerializeException.class, () ->
         coercing.serialize("foo"));
-  }
-
-  @Test
-  void serialize_ReturnsDateTime_ForValidLiteral() {
-    // Arrange
-    Literal dateTimeLiteral = VF.createLiteral(
-        datatypeFactory.newXMLGregorianCalendar("2018-05-30T09:30:10+02:00"));
-
-    // Act
-    ZonedDateTime dateTime = coercing.serialize(dateTimeLiteral);
-
-    // Assert
-    ZonedDateTime expected = ZonedDateTime.of(2018, 5, 30, 9, 30, 10, 0, ZoneId.of("GMT+2"));
-    assertThat(dateTime.isEqual(expected), is(equalTo(true)));
-  }
-
-  @Test
-  void serialize_ReturnsDateTime_ForInvalidLiteral() {
-    // Act / Assert
-    assertThrows(CoercingSerializeException.class, () ->
-        coercing.serialize(VF.createLiteral("foo")));
   }
 
   @Test

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -14,10 +14,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.eclipse.rdf4j</groupId>
-      <artifactId>rdf4j-model</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <exclusions>


### PR DESCRIPTION
Every unknown literal type is now converted to `String` instead of `Literal`. This greatly improves interoperability with generic modules.

For example:
* Language strings are now handled the right way
* `Date`/`DateTime` scalar implementations got a lot simpler
* `core` module got rid of the `rdf4j-model` dependency
