### PR TITLE
IHR2-2182 - Use beer ontology for unit and integration tests.

### DIFF
--- a/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/Constants.java
+++ b/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/Constants.java
@@ -32,45 +32,45 @@ public final class Constants {
 
   // Properties
 
-  public static final IRI SHAPE_GRAPH = VF.createIRI("http://example/shapes");
+  public static final IRI SHAPE_GRAPH = VF.createIRI("https://github.com/dotwebstack/beer/shapes");
 
-  public static final String SHAPE_PREFIX = "http://example/shapes#";
+  public static final String SHAPE_PREFIX = "https://github.com/dotwebstack/beer/shapes#";
 
   // Query
 
-  public static final String BUILDING_FIELD = "building";
+  public static final String BREWERY_FIELD = "brewery";
 
   // Building
 
-  public static final String BUILDING_TYPE = "Building";
+  public static final String BREWERY_TYPE = "Brewery";
 
-  public static final IRI BUILDING_SHAPE = VF.createIRI(SHAPE_PREFIX.concat(BUILDING_TYPE));
+  public static final IRI BREWERY_SHAPE = VF.createIRI(SHAPE_PREFIX.concat(BREWERY_TYPE));
 
-  public static final IRI BUILDING_CLASS = VF.createIRI("http://example/def#Building");
+  public static final IRI BREWERY_CLASS = VF.createIRI("https://github.com/dotwebstack/beer/def#Building");
 
-  public static final IRI BUILDING_EXAMPLE_1 = VF.createIRI("http://example/building/123");
+  public static final IRI BREWERY_EXAMPLE_1 = VF.createIRI("https://github.com/dotwebstack/beer/identifier/brewery/123");
 
-  // Building.identifier
+  // Brewery.id
 
-  public static final String BUILDING_IDENTIFIER_FIELD = "identifier";
+  public static final String BREWERY_IDENTIFIER_FIELD = "identifier";
 
-  public static final IRI BUILDING_IDENTIFIER_PATH = VF.createIRI("http://example/def#identifier");
+  public static final IRI BREWERY_IDENTIFIER_PATH = VF.createIRI("https://github.com/dotwebstack/beer/def#identifier");
 
-  public static final Literal BUILDING_IDENTIFIER_EXAMPLE_1 = VF.createLiteral("123");
+  public static final Literal BREWERY_IDENTIFIER_EXAMPLE_1 = VF.createLiteral("123");
 
-  // Building.height
+  // Brewery.name
 
-  public static final String BUILDING_HEIGHT_FIELD = "height";
+  public static final String BREWERY_NAME_FIELD = "name";
 
-  public static final Literal BUILDING_HEIGHT_EXAMPLE_1 = VF.createLiteral(24);
+  public static final Literal BREWERY_NAME_EXAMPLE_1 = VF.createLiteral("Brouwerij 1923");
 
-  // Building.builtAt
+  // Brewery.founded
 
-  public static final String BUILDING_BUILT_AT_FIELD = "builtAt";
+  public static final String BREWERY_FOUNDED_FIELD = "founded";
 
-  public static final IRI BUILDING_BUILT_AT_PATH = VF.createIRI("http://example/def#builtAt");
+  public static final IRI BREWERY_FOUNDED_PATH = VF.createIRI("https://github.com/dotwebstack/beer/def##founded");
 
-  public static final Literal BUILDING_BUILT_AT_EXAMPLE_1 = VF
+  public static final Literal BREWERY_FOUNDED_EXAMPLE_1 = VF
       .createLiteral(datatypeFactory.newXMLGregorianCalendar("2018-05-30T09:30:10+02:00"));
 
 }

--- a/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/IriConverterTest.java
+++ b/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/IriConverterTest.java
@@ -1,6 +1,6 @@
 package org.dotwebstack.framework.backend.rdf4j;
 
-import static org.dotwebstack.framework.backend.rdf4j.Constants.BUILDING_CLASS;
+import static org.dotwebstack.framework.backend.rdf4j.Constants.BREWERY_CLASS;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -16,13 +16,13 @@ class IriConverterTest {
   @Test
   void convert_ConvertsToIri_ForValidString() {
     // Arrange
-    String input = BUILDING_CLASS.stringValue();
+    String input = BREWERY_CLASS.stringValue();
 
     // Act
     IRI result = iriConverter.convert(input);
 
     // Assert
-    assertThat(result, is(equalTo(BUILDING_CLASS)));
+    assertThat(result, is(equalTo(BREWERY_CLASS)));
   }
 
   @Test

--- a/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/Rdf4jConfigurationTest.java
+++ b/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/Rdf4jConfigurationTest.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableMap;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.net.URISyntaxException;
 import java.util.Map;
 import lombok.Cleanup;
 import org.dotwebstack.framework.backend.rdf4j.Rdf4jProperties.RepositoryProperties;
@@ -218,7 +217,7 @@ class Rdf4jConfigurationTest {
         .nodeShapeRegistry(repositoryManager, rdf4jProperties);
 
     // Assert
-    assertThat(nodeShapeRegistry.get(Constants.BUILDING_SHAPE), is(notNullValue()));
+    assertThat(nodeShapeRegistry.get(Constants.BREWERY_SHAPE), is(notNullValue()));
   }
 
 }

--- a/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/Rdf4jIntegrationTest.java
+++ b/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/Rdf4jIntegrationTest.java
@@ -1,11 +1,12 @@
 package org.dotwebstack.framework.backend.rdf4j;
 
-import static org.dotwebstack.framework.backend.rdf4j.Constants.BUILDING_BUILT_AT_EXAMPLE_1;
-import static org.dotwebstack.framework.backend.rdf4j.Constants.BUILDING_BUILT_AT_FIELD;
-import static org.dotwebstack.framework.backend.rdf4j.Constants.BUILDING_HEIGHT_EXAMPLE_1;
-import static org.dotwebstack.framework.backend.rdf4j.Constants.BUILDING_HEIGHT_FIELD;
-import static org.dotwebstack.framework.backend.rdf4j.Constants.BUILDING_IDENTIFIER_EXAMPLE_1;
-import static org.dotwebstack.framework.backend.rdf4j.Constants.BUILDING_IDENTIFIER_FIELD;
+import static org.dotwebstack.framework.backend.rdf4j.Constants.BREWERY_FIELD;
+import static org.dotwebstack.framework.backend.rdf4j.Constants.BREWERY_FOUNDED_EXAMPLE_1;
+import static org.dotwebstack.framework.backend.rdf4j.Constants.BREWERY_FOUNDED_FIELD;
+import static org.dotwebstack.framework.backend.rdf4j.Constants.BREWERY_IDENTIFIER_EXAMPLE_1;
+import static org.dotwebstack.framework.backend.rdf4j.Constants.BREWERY_IDENTIFIER_FIELD;
+import static org.dotwebstack.framework.backend.rdf4j.Constants.BREWERY_NAME_EXAMPLE_1;
+import static org.dotwebstack.framework.backend.rdf4j.Constants.BREWERY_NAME_FIELD;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -30,7 +31,7 @@ class Rdf4jIntegrationTest {
   @Test
   void graphqlQuery_ReturnsMap_ForObjectQueryField() {
     // Arrange
-    String query = "{ building(identifier: \"123\") { identifier, height, builtAt }}";
+    String query = "{ brewery(identifier: \"123\") { identifier, name, founded }}";
 
     // Act
     ExecutionResult result = graphQL.execute(query);
@@ -38,11 +39,11 @@ class Rdf4jIntegrationTest {
     // Assert
     assertThat(result.getErrors().isEmpty(), is(equalTo(true)));
     Map<String, Object> data = result.getData();
-    assertThat(data, IsMapContaining.hasEntry(Constants.BUILDING_FIELD, ImmutableMap
-        .of(BUILDING_IDENTIFIER_FIELD, BUILDING_IDENTIFIER_EXAMPLE_1.stringValue(),
-            BUILDING_HEIGHT_FIELD, BUILDING_HEIGHT_EXAMPLE_1.intValue(),
-            BUILDING_BUILT_AT_FIELD,
-            ZonedDateTime.parse(BUILDING_BUILT_AT_EXAMPLE_1.stringValue()))));
+    assertThat(data, IsMapContaining.hasEntry(BREWERY_FIELD, ImmutableMap
+        .of(BREWERY_IDENTIFIER_FIELD, BREWERY_IDENTIFIER_EXAMPLE_1.stringValue(),
+                BREWERY_NAME_FIELD, BREWERY_NAME_EXAMPLE_1.stringValue(),
+                BREWERY_FOUNDED_FIELD,
+            ZonedDateTime.parse(BREWERY_FOUNDED_EXAMPLE_1.stringValue()))));
   }
 
 }

--- a/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/ValueUtilsTest.java
+++ b/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/ValueUtilsTest.java
@@ -66,10 +66,10 @@ class ValueUtilsTest {
   @Test
   void convertValue_ReturnsInput_ForNonLiterals() {
     // Act
-    Object result = ValueUtils.convertValue(Constants.BUILDING_EXAMPLE_1);
+    Object result = ValueUtils.convertValue(Constants.BREWERY_EXAMPLE_1);
 
     // Assert
-    assertThat(result, is(equalTo(Constants.BUILDING_EXAMPLE_1)));
+    assertThat(result, is(equalTo(Constants.BREWERY_EXAMPLE_1)));
   }
 
   @Test

--- a/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/query/ValueFetcherTest.java
+++ b/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/query/ValueFetcherTest.java
@@ -1,13 +1,13 @@
 package org.dotwebstack.framework.backend.rdf4j.query;
 
-import static org.dotwebstack.framework.backend.rdf4j.Constants.BUILDING_BUILT_AT_EXAMPLE_1;
-import static org.dotwebstack.framework.backend.rdf4j.Constants.BUILDING_BUILT_AT_FIELD;
-import static org.dotwebstack.framework.backend.rdf4j.Constants.BUILDING_BUILT_AT_PATH;
-import static org.dotwebstack.framework.backend.rdf4j.Constants.BUILDING_EXAMPLE_1;
-import static org.dotwebstack.framework.backend.rdf4j.Constants.BUILDING_IDENTIFIER_EXAMPLE_1;
-import static org.dotwebstack.framework.backend.rdf4j.Constants.BUILDING_IDENTIFIER_FIELD;
-import static org.dotwebstack.framework.backend.rdf4j.Constants.BUILDING_IDENTIFIER_PATH;
-import static org.dotwebstack.framework.backend.rdf4j.Constants.BUILDING_TYPE;
+import static org.dotwebstack.framework.backend.rdf4j.Constants.BREWERY_EXAMPLE_1;
+import static org.dotwebstack.framework.backend.rdf4j.Constants.BREWERY_FOUNDED_EXAMPLE_1;
+import static org.dotwebstack.framework.backend.rdf4j.Constants.BREWERY_FOUNDED_FIELD;
+import static org.dotwebstack.framework.backend.rdf4j.Constants.BREWERY_FOUNDED_PATH;
+import static org.dotwebstack.framework.backend.rdf4j.Constants.BREWERY_IDENTIFIER_EXAMPLE_1;
+import static org.dotwebstack.framework.backend.rdf4j.Constants.BREWERY_IDENTIFIER_FIELD;
+import static org.dotwebstack.framework.backend.rdf4j.Constants.BREWERY_IDENTIFIER_PATH;
+import static org.dotwebstack.framework.backend.rdf4j.Constants.BREWERY_TYPE;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -38,53 +38,54 @@ class ValueFetcherTest {
   void get_ReturnsConvertedLiteral_ForBuiltInScalarField() {
     // Arrange
     ValueFetcher valueFetcher = new ValueFetcher(PropertyShape.builder()
-        .name(BUILDING_IDENTIFIER_FIELD)
-        .path(BUILDING_IDENTIFIER_PATH)
+        .name(BREWERY_IDENTIFIER_FIELD)
+        .path(BREWERY_IDENTIFIER_PATH)
         .build());
     Model model = new ModelBuilder()
-        .add(BUILDING_EXAMPLE_1, BUILDING_IDENTIFIER_PATH, BUILDING_IDENTIFIER_EXAMPLE_1)
+        .add(BREWERY_EXAMPLE_1, BREWERY_IDENTIFIER_PATH,
+                BREWERY_IDENTIFIER_EXAMPLE_1)
         .build();
     when(environment.getFieldType()).thenReturn(Scalars.GraphQLID);
-    when(environment.getSource()).thenReturn(new QuerySolution(model, BUILDING_EXAMPLE_1));
+    when(environment.getSource()).thenReturn(new QuerySolution(model, BREWERY_EXAMPLE_1));
 
     // Act
     Object result = valueFetcher.get(environment);
 
     // Assert
-    assertThat(result, is(equalTo(BUILDING_IDENTIFIER_EXAMPLE_1.stringValue())));
+    assertThat(result, is(equalTo(BREWERY_IDENTIFIER_EXAMPLE_1.stringValue())));
   }
 
   @Test
   void get_ReturnsLiteral_ForForeignScalarField() {
     // Arrange
     ValueFetcher valueFetcher = new ValueFetcher(PropertyShape.builder()
-        .name(BUILDING_BUILT_AT_FIELD)
-        .path(BUILDING_BUILT_AT_PATH)
+        .name(BREWERY_FOUNDED_FIELD)
+        .path(BREWERY_FOUNDED_PATH)
         .build());
     Model model = new ModelBuilder()
-        .add(BUILDING_EXAMPLE_1, BUILDING_BUILT_AT_PATH, BUILDING_BUILT_AT_EXAMPLE_1)
+        .add(BREWERY_EXAMPLE_1, BREWERY_FOUNDED_PATH, BREWERY_FOUNDED_EXAMPLE_1)
         .build();
     when(environment.getFieldType()).thenReturn(
         CoreScalars.DATETIME);
-    when(environment.getSource()).thenReturn(new QuerySolution(model, BUILDING_EXAMPLE_1));
+    when(environment.getSource()).thenReturn(new QuerySolution(model, BREWERY_EXAMPLE_1));
 
     // Act
     Object result = valueFetcher.get(environment);
 
     // Assert
-    assertThat(result, is(equalTo(BUILDING_BUILT_AT_EXAMPLE_1)));
+    assertThat(result, is(equalTo(BREWERY_FOUNDED_EXAMPLE_1)));
   }
 
   @Test
   void get_ReturnsNull_ForAbsentScalarField() {
     // Arrange
     ValueFetcher valueFetcher = new ValueFetcher(PropertyShape.builder()
-        .name(BUILDING_IDENTIFIER_FIELD)
-        .path(BUILDING_IDENTIFIER_PATH)
+        .name(BREWERY_IDENTIFIER_FIELD)
+        .path(BREWERY_IDENTIFIER_PATH)
         .build());
     Model model = new TreeModel();
     when(environment.getFieldType()).thenReturn(Scalars.GraphQLID);
-    when(environment.getSource()).thenReturn(new QuerySolution(model, BUILDING_EXAMPLE_1));
+    when(environment.getSource()).thenReturn(new QuerySolution(model, BREWERY_EXAMPLE_1));
 
     // Act
     Object result = valueFetcher.get(environment);
@@ -99,9 +100,9 @@ class ValueFetcherTest {
     ValueFetcher valueFetcher = new ValueFetcher(PropertyShape.builder().build());
     Model model = new TreeModel();
     when(environment.getFieldType()).thenReturn(GraphQLObjectType.newObject()
-        .name(BUILDING_TYPE)
+        .name(BREWERY_TYPE)
         .build());
-    when(environment.getSource()).thenReturn(new QuerySolution(model, BUILDING_EXAMPLE_1));
+    when(environment.getSource()).thenReturn(new QuerySolution(model, BREWERY_EXAMPLE_1));
 
     // Act / Assert
     assertThrows(UnsupportedOperationException.class, () ->

--- a/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/scalars/IriCoercingTest.java
+++ b/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/scalars/IriCoercingTest.java
@@ -32,24 +32,24 @@ class IriCoercingTest {
   @Test
   void parseLiteral_ReturnsIri_ForIriValue() {
     // Act
-    IRI result = coercing.parseLiteral(Constants.BUILDING_SHAPE);
+    IRI result = coercing.parseLiteral(Constants.BREWERY_SHAPE);
 
     // Assert
-    assertThat(result, is(equalTo(Constants.BUILDING_SHAPE)));
+    assertThat(result, is(equalTo(Constants.BREWERY_SHAPE)));
   }
 
   @Test
   void parseLiteral_ReturnsIri_ForValidStringValue() {
     // Arrange
     StringValue stringValue = StringValue
-        .newStringValue(Constants.BUILDING_SHAPE.stringValue())
+        .newStringValue(Constants.BREWERY_SHAPE.stringValue())
         .build();
 
     // Act
     IRI result = coercing.parseLiteral(stringValue);
 
     // Assert
-    assertThat(result, is(equalTo(Constants.BUILDING_SHAPE)));
+    assertThat(result, is(equalTo(Constants.BREWERY_SHAPE)));
   }
 
   @Test

--- a/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/shacl/NodeShapeRegistryTest.java
+++ b/backend/rdf4j/src/test/java/org/dotwebstack/framework/backend/rdf4j/shacl/NodeShapeRegistryTest.java
@@ -1,7 +1,7 @@
 package org.dotwebstack.framework.backend.rdf4j.shacl;
 
-import static org.dotwebstack.framework.backend.rdf4j.Constants.BUILDING_SHAPE;
-import static org.dotwebstack.framework.backend.rdf4j.Constants.BUILDING_TYPE;
+import static org.dotwebstack.framework.backend.rdf4j.Constants.BREWERY_SHAPE;
+import static org.dotwebstack.framework.backend.rdf4j.Constants.BREWERY_TYPE;
 import static org.dotwebstack.framework.backend.rdf4j.Constants.SHAPE_PREFIX;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -32,10 +32,10 @@ class NodeShapeRegistryTest {
   @Test
   void register_addsNodeShapeToRegistry() {
     // Act
-    nodeShapeRegistry.register(BUILDING_SHAPE, nodeShape);
+    nodeShapeRegistry.register(BREWERY_SHAPE, nodeShape);
 
     // Assert
-    assertThat(nodeShapeRegistry.get(BUILDING_SHAPE), is(equalTo(nodeShape)));
+    assertThat(nodeShapeRegistry.get(BREWERY_SHAPE), is(equalTo(nodeShape)));
   }
 
   @Test
@@ -51,7 +51,7 @@ class NodeShapeRegistryTest {
   void get_returnsNodeShape_ForGivenObjectType() {
     // Arrange
     GraphQLObjectType objectType = GraphQLObjectType.newObject()
-        .name(BUILDING_TYPE)
+        .name(BREWERY_TYPE)
         .build();
 
     // Act

--- a/backend/rdf4j/src/test/resources/application.yml
+++ b/backend/rdf4j/src/test/resources/application.yml
@@ -4,5 +4,5 @@ spring.main.banner-mode: 'off'
 dotwebstack:
   rdf4j:
     shape:
-      graph: http://example/shapes
-      prefix: http://example/shapes#
+      graph: https://github.com/dotwebstack/beer/shapes
+      prefix: https://github.com/dotwebstack/beer/shapes#

--- a/backend/rdf4j/src/test/resources/config/model/data.trig
+++ b/backend/rdf4j/src/test/resources/config/model/data.trig
@@ -1,15 +1,19 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-@prefix ex_def: <http://example/def#> .
-@prefix ex_building: <http://example/building/> .
+@prefix schema: <http://schema.org/> .
+@prefix beer: <https://github.com/dotwebstack/beer/> .
+@prefix beer_brewery: <https://github.com/dotwebstack/beer/id/brewery/> .
+@prefix beer_def: <https://github.com/dotwebstack/beer/def#> .
+@prefix beer_sh: <https://github.com/dotwebstack/beer/shapes#> .
 
-ex_building:123 a ex_def:Building ;
-  ex_def:identifier "123" ;
-  ex_def:height "24"^^xsd:int ;
-  ex_def:builtAt "2018-05-30T09:30:10+02:00"^^xsd:dateTime
+beer_brewery:123 a beer_def:Brewery ;
+  beer_def:identifier "123" ;
+  schema:name "Brouwerij 1923"^^xsd:string ;
+  beer_def:founded "2018-05-30T09:30:10+02:00"^^xsd:dateTime
 .
 
-ex_building:456 a ex_def:Building ;
-  ex_def:identifier "456" ;
-  ex_def:height "5"^^xsd:int ;
+beer_brewery:456 a beer_def:Brewery ;
+  beer_def:identifier "456" ;
+  schema:name "Brouwerij Het 58e Genot i.o."^^xsd:dateTime ;
+  beer_def:founded "2010-05-10T09:30:10+02:00"^^xsd:dateTime
 .

--- a/backend/rdf4j/src/test/resources/config/model/shapes.trig
+++ b/backend/rdf4j/src/test/resources/config/model/shapes.trig
@@ -1,39 +1,40 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix ex: <http://example/> .
-@prefix ex_def: <http://example/def#> .
-@prefix ex_sh: <http://example/shapes#> .
+@prefix schema: <http://schema.org/> .
+@prefix beer: <https://github.com/dotwebstack/beer/> .
+@prefix beer_def: <https://github.com/dotwebstack/beer/def#> .
+@prefix beer_sh: <https://github.com/dotwebstack/beer/shapes#> .
 
-ex:shapes {
-  ex_sh:Building a sh:NodeShape ;
-    sh:targetClass ex_def:Building ;
+beer:shapes {
+  beer_sh:Brewery a sh:NodeShape ;
+    sh:targetClass beer_def:Brewery ;
     sh:property
-      ex_sh:Building_identifier ,
-      ex_sh:Building_height ,
-      ex_sh:Building_builtAt ;
+      beer_sh:Brewery_identifier ,
+      beer_sh:Brewery_name ,
+      beer_sh:Brewery_founded ;
   .
 
-  ex_sh:Building_identifier a sh:PropertyShape ;
+  beer_sh:Brewery_identifier a sh:PropertyShape ;
     sh:name "identifier" ;
-    sh:path ex_def:identifier ;
+    sh:path beer_def:identifier ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
     sh:nodeKind sh:Literal ;
     sh:datatype xsd:string ;
   .
 
-  ex_sh:Building_height a sh:PropertyShape ;
-    sh:name "height" ;
-    sh:path ex_def:height ;
+  beer_sh:Brewery_name a sh:PropertyShape ;
+    sh:name "name" ;
+    sh:path schema:name ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
     sh:nodeKind sh:Literal ;
-    sh:datatype xsd:int ;
+    sh:datatype xsd:string ;
   .
 
-  ex_sh:Building_builtAt a sh:PropertyShape ;
-    sh:name "builtAt" ;
-    sh:path ex_def:builtAt ;
+  beer_sh:Brewery_founded a sh:PropertyShape ;
+    sh:name "founded" ;
+    sh:path beer_def:founded ;
     sh:minCount 0 ;
     sh:maxCount 1 ;
     sh:nodeKind sh:Literal ;

--- a/backend/rdf4j/src/test/resources/config/schema.graphqls
+++ b/backend/rdf4j/src/test/resources/config/schema.graphqls
@@ -3,14 +3,14 @@ schema {
 }
 
 type Query {
-  building(identifier: ID!): Building!
-    @sparql(repository: "local", subject: "http://example/building/${identifier}")
-  buildings: [Building!]!
+  brewery(identifier: ID!): Brewery!
+    @sparql(repository: "local", subject: "https://github.com/dotwebstack/beer/id/brewery/${identifier}")
+  breweries: [Brewery!]!
     @sparql(repository: "local")
 }
 
-type Building {
+type Brewery {
   identifier: ID!
-  height: Int!
-  builtAt: DateTime!
+  name: String!
+  founded: DateTime!
 }

--- a/core/src/test/java/org/dotwebstack/framework/core/Constants.java
+++ b/core/src/test/java/org/dotwebstack/framework/core/Constants.java
@@ -11,30 +11,30 @@ final class Constants {
 
   // Query
 
-  public static final String BUILDING_FIELD = "building";
+  public static final String BREWERY_FIELD = "brewery";
 
-  // Building.identifier
+  // Brewery.id
 
-  public static final String BUILDING_IDENTIFIER_FIELD = "identifier";
+  public static final String BREWERY_IDENTIFIER_FIELD = "identifier";
 
-  public static final String BUILDING_IDENTIFIER_EXAMPLE_1 = "123";
+  public static final String BREWERY_IDENTIFIER_EXAMPLE_1 = "123";
 
-  // Building.height
+  // Brewery.name
 
-  public static final String BUILDING_HEIGHT_FIELD = "height";
+  public static final String BREWERY_NAME_FIELD = "name";
 
-  public static final int BUILDING_HEIGHT_EXAMPLE_1 = 24;
+  public static final String BREWERY_NAME_EXAMPLE_1 = "Brouwerij 1923";
 
-  // Building.builtAt
+  // Brewery.founded
 
-  public static final String BUILDING_BUILT_AT_FIELD = "builtAt";
+  public static final String BREWERY_FOUNDED_FIELD = "founded";
 
-  public static final ZonedDateTime BUILDING_BUILT_AT_EXAMPLE_1 = ZonedDateTime.now();
+  public static final ZonedDateTime BREWERY_FOUNDED_EXAMPLE_1 = ZonedDateTime.now();
 
-  // Building.builtAtYear
+  // Building.foundedAtYear
 
-  public static final String BUILDING_BUILT_AT_YEAR_FIELD = "builtAtYear";
+  public static final String BREWERY_FOUNDED_AT_YEAR_FIELD = "foundedAtYear";
 
-  public static final int BUILDING_BUILT_AT_YEAR_EXAMPLE_1 = BUILDING_BUILT_AT_EXAMPLE_1.getYear();
+  public static final int BREWERY_FOUNDED_AT_YEAR_EXAMPLE_1 = BREWERY_FOUNDED_EXAMPLE_1.getYear();
 
 }

--- a/core/src/test/java/org/dotwebstack/framework/core/GraphqlIntegrationConfigurer.java
+++ b/core/src/test/java/org/dotwebstack/framework/core/GraphqlIntegrationConfigurer.java
@@ -15,13 +15,12 @@ class GraphqlIntegrationConfigurer implements GraphqlConfigurer {
   public void configureRuntimeWiring(@NonNull RuntimeWiring.Builder builder) {
     // Register data fetcher for test data
     builder.codeRegistry(GraphQLCodeRegistry.newCodeRegistry()
-        .dataFetcher(FieldCoordinates.coordinates("Query", Constants.BUILDING_FIELD),
+        .dataFetcher(FieldCoordinates.coordinates("Query", Constants.BREWERY_FIELD),
             (DataFetcher<Object>) dataFetchingEnvironment -> ImmutableMap.of(
-                Constants.BUILDING_IDENTIFIER_FIELD, Constants.BUILDING_IDENTIFIER_EXAMPLE_1,
-                Constants.BUILDING_HEIGHT_FIELD,
-                Constants.BUILDING_HEIGHT_EXAMPLE_1, Constants.BUILDING_BUILT_AT_FIELD,
-                Constants.BUILDING_BUILT_AT_EXAMPLE_1,
-                Constants.BUILDING_BUILT_AT_YEAR_FIELD, Constants.BUILDING_BUILT_AT_EXAMPLE_1)));
+                Constants.BREWERY_IDENTIFIER_FIELD, Constants.BREWERY_IDENTIFIER_EXAMPLE_1,
+                Constants.BREWERY_NAME_FIELD, Constants.BREWERY_NAME_EXAMPLE_1,
+                Constants.BREWERY_FOUNDED_FIELD, Constants.BREWERY_FOUNDED_EXAMPLE_1,
+                Constants.BREWERY_FOUNDED_AT_YEAR_FIELD, Constants.BREWERY_FOUNDED_EXAMPLE_1)));
   }
 
 }

--- a/core/src/test/java/org/dotwebstack/framework/core/GraphqlIntegrationTest.java
+++ b/core/src/test/java/org/dotwebstack/framework/core/GraphqlIntegrationTest.java
@@ -1,14 +1,14 @@
 package org.dotwebstack.framework.core;
 
-import static org.dotwebstack.framework.core.Constants.BUILDING_BUILT_AT_EXAMPLE_1;
-import static org.dotwebstack.framework.core.Constants.BUILDING_BUILT_AT_FIELD;
-import static org.dotwebstack.framework.core.Constants.BUILDING_BUILT_AT_YEAR_EXAMPLE_1;
-import static org.dotwebstack.framework.core.Constants.BUILDING_BUILT_AT_YEAR_FIELD;
-import static org.dotwebstack.framework.core.Constants.BUILDING_FIELD;
-import static org.dotwebstack.framework.core.Constants.BUILDING_HEIGHT_EXAMPLE_1;
-import static org.dotwebstack.framework.core.Constants.BUILDING_HEIGHT_FIELD;
-import static org.dotwebstack.framework.core.Constants.BUILDING_IDENTIFIER_EXAMPLE_1;
-import static org.dotwebstack.framework.core.Constants.BUILDING_IDENTIFIER_FIELD;
+import static org.dotwebstack.framework.core.Constants.BREWERY_FIELD;
+import static org.dotwebstack.framework.core.Constants.BREWERY_FOUNDED_AT_YEAR_EXAMPLE_1;
+import static org.dotwebstack.framework.core.Constants.BREWERY_FOUNDED_AT_YEAR_FIELD;
+import static org.dotwebstack.framework.core.Constants.BREWERY_FOUNDED_EXAMPLE_1;
+import static org.dotwebstack.framework.core.Constants.BREWERY_FOUNDED_FIELD;
+import static org.dotwebstack.framework.core.Constants.BREWERY_IDENTIFIER_EXAMPLE_1;
+import static org.dotwebstack.framework.core.Constants.BREWERY_IDENTIFIER_FIELD;
+import static org.dotwebstack.framework.core.Constants.BREWERY_NAME_EXAMPLE_1;
+import static org.dotwebstack.framework.core.Constants.BREWERY_NAME_FIELD;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -32,7 +32,7 @@ class GraphqlIntegrationTest {
   @Test
   void graphqlQuery_ReturnsMap_ForObjectQueryField() {
     // Arrange
-    String query = "{ building(identifier: \"123\") { identifier, height, builtAt, builtAtYear }}";
+    String query = "{ brewery(identifier: \"123\") { identifier, name, founded, foundedAtYear }}";
 
     // Act
     ExecutionResult result = graphQL.execute(query);
@@ -40,10 +40,12 @@ class GraphqlIntegrationTest {
     // Assert
     assertThat(result.getErrors().isEmpty(), is(equalTo(true)));
     Map<String, Object> data = result.getData();
-    assertThat(data, IsMapContaining.hasEntry(BUILDING_FIELD, ImmutableMap
-        .of(BUILDING_IDENTIFIER_FIELD, BUILDING_IDENTIFIER_EXAMPLE_1, BUILDING_HEIGHT_FIELD,
-            BUILDING_HEIGHT_EXAMPLE_1, BUILDING_BUILT_AT_FIELD, BUILDING_BUILT_AT_EXAMPLE_1,
-            BUILDING_BUILT_AT_YEAR_FIELD, BUILDING_BUILT_AT_YEAR_EXAMPLE_1)));
+
+    assertThat(data, IsMapContaining.hasEntry(BREWERY_FIELD,
+            ImmutableMap.of(BREWERY_IDENTIFIER_FIELD, BREWERY_IDENTIFIER_EXAMPLE_1,
+                            BREWERY_NAME_FIELD,BREWERY_NAME_EXAMPLE_1,
+                            BREWERY_FOUNDED_FIELD,BREWERY_FOUNDED_EXAMPLE_1,
+                            BREWERY_FOUNDED_AT_YEAR_FIELD,BREWERY_FOUNDED_AT_YEAR_EXAMPLE_1)));
   }
 
 }

--- a/core/src/test/resources/config/schema.graphqls
+++ b/core/src/test/resources/config/schema.graphqls
@@ -3,13 +3,13 @@ schema {
 }
 
 type Query {
-  building(identifier: ID!): Building!
+  brewery(identifier: ID!): Brewery!
 }
 
-type Building {
+type Brewery {
   identifier: ID!
-  height: Int!
-  builtAt: DateTime!
-  builtAtYear: Int!
-    @transform(expr: "builtAtYear.getYear()")
+  name: String!
+  founded: DateTime!
+  foundedAtYear: Int!
+    @transform(expr: "foundedAtYear.getYear()")
 }

--- a/example/src/main/resources/application.yml
+++ b/example/src/main/resources/application.yml
@@ -4,14 +4,9 @@ logging:
 dotwebstack:
   rdf4j:
     shape:
-      graph: http://dbeerpedia.com/id/shapes
-      prefix: http://dbeerpedia.com/def/
+      graph: https://github.com/dotwebstack/beer/shapes
+      prefix: https://github.com/dotwebstack/beer/shapes#
     prefixes:
       rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
-      dbeer: http://dbeerpedia.com/def#
-      brewery_id: http://dbeerpedia.com/id/brewery/
-    repositories:
-      data:
-        type: sparql
-        args:
-          endpointUrl: https://data.pdok.nl/sparql
+      beer_def: https://github.com/dotwebstack/beer/def#
+      brewery_id: https://github.com/dotwebstack/beer/id/brewery/

--- a/example/src/main/resources/application.yml
+++ b/example/src/main/resources/application.yml
@@ -4,12 +4,12 @@ logging:
 dotwebstack:
   rdf4j:
     shape:
-      graph: http://bag.basisregistraties.overheid.nl/bag/id/shapes/imbag
-      prefix: http://bag.basisregistraties.overheid.nl/def/bag/
+      graph: http://dbeerpedia.com/id/shapes
+      prefix: http://dbeerpedia.com/def/
     prefixes:
       rdf: http://www.w3.org/1999/02/22-rdf-syntax-ns#
-      bag: http://bag.basisregistraties.overheid.nl/def/bag#
-      bag_pnd: http://bag.basisregistraties.overheid.nl/bag/id/pand/
+      dbeer: http://dbeerpedia.com/def#
+      brewery_id: http://dbeerpedia.com/id/brewery/
     repositories:
       data:
         type: sparql

--- a/example/src/main/resources/config/model/data.trig
+++ b/example/src/main/resources/config/model/data.trig
@@ -1,16 +1,16 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 @prefix schema: <http://schema.org/> .
-@prefix dbeer: <http://dbeerpedia.com/def#> .
-@prefix brewery_id: <http://dbeerpedia.com/id/brewery/> .
+@prefix beer_def: <https://github.com/dotwebstack/beer/def#> .
+@prefix brewery_id: <https://github.com/dotwebstack/beer/id/brewery/> .
 
 {
-	brewery_id:1 a dbeer:Brewery ;
-	    dbeer:id "1" ;
-		dbeer:brewmasters "Jeroen van Hees" ;
-		dbeer:founded "2014" ;
-		dbeer:group "Onafhankelijk" ;
-		dbeer:owners "J.v.Hees" , "I.Verhoef" , "L.du Clou" , "M.Kuijpers" ;
+	brewery_id:1 a beer_def:Brewery ;
+	    beer_def:identifier "1" ;
+		beer_def:brewmasters "Jeroen van Hees" ;
+		beer_def:founded "2014-01-01T00:00:00+02:00"^^xsd:dateTime ;
+		beer_def:group "Onafhankelijk" ;
+		beer_def:owners "J.v.Hees" , "I.Verhoef" , "L.du Clou" , "M.Kuijpers" ;
 		schema:state "Zuid-Holland" ;
 		schema:address _:b1 ;
 		schema:email "bier@brouwerij1923.nl" ;
@@ -19,19 +19,17 @@
 		schema:telephone "06-10816700" ;
 		schema:url <http://www.brouwerij1923.nl> .
 
-	_:b1 dbeer:bagAdresseerbaarobject <https://bag.basisregistraties.overheid.nl/bag/id/verblijfsobject/1892010000687950> ;
-		dbeer:bagNummeraanduiding <https://bag.basisregistraties.overheid.nl/bag/id/nummeraanduiding/1892200000687949> ;
-		schema:addressLocality "Moordrecht" ;
+	_:b1 schema:addressLocality "Moordrecht" ;
 		schema:latitude "51.98776545" ;
 		schema:longitude "4.67090183" ;
 		schema:postalCode "2841 XB" ;
 		schema:streetAddress "Burgemeester Brandtstraat 23" .
 
-	brewery_id:2 a dbeer:Brewery ;
-	    dbeer:id "2" ;
-		dbeer:address _:b3 ;
-		dbeer:founded "2017" ;
-		dbeer:group "Onafhankelijk" ;
+	brewery_id:2 a beer_def:Brewery ;
+	    beer_def:identifier "2" ;
+		beer_def:address _:b3 ;
+		beer_def:founded "2017-01-01T00:00:00+02:00"^^xsd:dateTime ;
+		beer_def:group "Onafhankelijk" ;
 		schema:state "Noord-Brabant" ;
 		schema:address _:b4 ;
 		schema:email "info@58egenot.nl" ;
@@ -39,9 +37,7 @@
 		schema:taxID "67452701" ;
 		schema:url <http://www.58egenot.nl> .
 
-	_:b3 dbeer:bagAdresseerbaarobject <https://bag.basisregistraties.overheid.nl/bag/id/verblijfsobject/0879010000008304> ;
-		dbeer:bagNummeraanduiding <https://bag.basisregistraties.overheid.nl/bag/id/nummeraanduiding/0879200000008304> ;
-		schema:addressLocality "Zundert" ;
+	_:b3 schema:addressLocality "Zundert" ;
 		schema:latitude "51.46376967" ;
 		schema:longitude "4.60958924" ;
 		schema:postalCode "4881 AZ" ;
@@ -50,15 +46,15 @@
 	_:b4 schema:postalCode "4881 AZ" ;
 		schema:streetAddress "Achtmaalseweg 137A" .
 
-	brewery_id:3 a dbeer:Brewery ;
-		dbeer:id "3" ;
-		dbeer:annualproduction "140000 hl." ;
-		dbeer:brewmasters "Erik Bielders" ;
-		dbeer:fax "046-4432835" ;
-		dbeer:founded "1870" ;
-		dbeer:group "Onafhankelijk" ;
-		dbeer:openinghours "Alle dagen van de week op aanvraag (12.30-16.00 uur)" ;
-		dbeer:owners "Harry Meens" ;
+	brewery_id:3 a beer_def:Brewery ;
+		beer_def:identifier "3" ;
+		beer_def:annualproduction "140000 hl." ;
+		beer_def:brewmasters "Erik Bielders" ;
+		beer_def:fax "046-4432835" ;
+		beer_def:founded "1870-01-01T00:00:00+02:00"^^xsd:dateTime ;
+		beer_def:group "Onafhankelijk" ;
+		beer_def:openinghours "Alle dagen van de week op aanvraag (12.30-16.00 uur)" ;
+		beer_def:owners "Harry Meens" ;
 		schema:state "Limburg" ;
 		schema:address _:b6 ;
 		schema:name "Alfa Brouwerij" ;
@@ -66,20 +62,18 @@
 		schema:telephone "046-4432888" ;
 		schema:url <http://www.alfabier.nl> .
 
-	_:b6 dbeer:bagAdresseerbaarobject <https://bag.basisregistraties.overheid.nl/bag/id/verblijfsobject/0962010000220594> ;
-		dbeer:bagNummeraanduiding <https://bag.basisregistraties.overheid.nl/bag/id/nummeraanduiding/0962200000220593> ;
-		schema:addressLocality "Schinnen" ;
+	_:b6 schema:addressLocality "Schinnen" ;
 		schema:latitude "50.93621081" ;
 		schema:longitude "5.89316555" ;
 		schema:postalCode "6365 AC" ;
 		schema:streetAddress "Thull 15" .
 
-	brewery_id:4 a dbeer:Brewery ;
-	    dbeer:id "4" ;
-		dbeer:brewmasters "Max Schreuder" , "Yvonne van Breda" ;
-		dbeer:founded "2014" ;
-		dbeer:group "Onafhankelijk" ;
-		dbeer:owners "Max Schreuder" , "Yvonne van Breda" ;
+	brewery_id:4 a beer_def:Brewery ;
+	    beer_def:identifier "4" ;
+		beer_def:brewmasters "Max Schreuder" , "Yvonne van Breda" ;
+		beer_def:founded "2014-01-01T00:00:00+02:00"^^xsd:dateTime ;
+		beer_def:group "Onafhankelijk" ;
+		beer_def:owners "Max Schreuder" , "Yvonne van Breda" ;
 		schema:state "Limburg" ;
 		schema:address _:b8 ;
 		schema:email "info@ambrass.nl" ;
@@ -88,21 +82,19 @@
 		schema:telephone "046-4009300" ;
 		schema:url <http://www.ambrass.nl> .
 
-	_:b8 dbeer:bagAdresseerbaarobject <https://bag.basisregistraties.overheid.nl/bag/id/verblijfsobject/1883010000004074> ;
-		dbeer:bagNummeraanduiding <https://bag.basisregistraties.overheid.nl/bag/id/nummeraanduiding/1883200000004074> ;
-		schema:addressLocality "Sittard" ;
+	_:b8 schema:addressLocality "Sittard" ;
 		schema:latitude "50.99279662" ;
 		schema:longitude "5.86118305" ;
 		schema:postalCode "6133 WZ" ;
 		schema:streetAddress "Berkenlaan 8" .
 
-	brewery_id:5 a dbeer:Brewery ;
-		dbeer:id "5" ;
-		dbeer:brewmasters "Doeke Visser" ;
-		dbeer:founded "2008" ;
-		dbeer:group "Onafhankelijk" ;
-		dbeer:openinghours "Bezoek op afspraak." ;
-		dbeer:owners "Doeke" , "Eva Visser" ;
+	brewery_id:5 a beer_def:Brewery ;
+		beer_def:identifier "5" ;
+		beer_def:brewmasters "Doeke Visser" ;
+		beer_def:founded "2008-01-01T00:00:00+02:00"^^xsd:dateTime ;
+		beer_def:group "Onafhankelijk" ;
+		beer_def:openinghours "Bezoek op afspraak." ;
+		beer_def:owners "Doeke" , "Eva Visser" ;
 		schema:state "Friesland" ;
 		schema:address _:b10 ;
 		schema:email "info@amelanderbier.nl" ;
@@ -111,9 +103,7 @@
 		schema:telephone "0519-554365" ;
 		schema:url <http://www.amelanderbier.nl> .
 
-	_:b10 dbeer:bagAdresseerbaarobject <https://bag.basisregistraties.overheid.nl/bag/id/verblijfsobject/0060010000131142> ;
-		dbeer:bagNummeraanduiding <https://bag.basisregistraties.overheid.nl/bag/id/nummeraanduiding/0060200000131141> ;
-		schema:addressLocality "Ballum" ;
+	_:b10 schema:addressLocality "Ballum" ;
 		schema:latitude "53.44025996" ;
 		schema:longitude "5.70644929" ;
 		schema:postalCode "9162 EC" ;

--- a/example/src/main/resources/config/model/data.trig
+++ b/example/src/main/resources/config/model/data.trig
@@ -1,21 +1,121 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-@prefix bag: <http://bag.basisregistraties.overheid.nl/def/bag#> .
-@prefix bag_beg: <http://bag.basisregistraties.overheid.nl/id/begrip/> .
-@prefix bag_pnd: <http://bag.basisregistraties.overheid.nl/bag/id/pand/> .
-@prefix bag_pnd_doc: <http://bag.basisregistraties.overheid.nl/bag/doc/pand/> .
+@prefix schema: <http://schema.org/> .
+@prefix dbeer: <http://dbeerpedia.com/def#> .
+@prefix brewery_id: <http://dbeerpedia.com/id/brewery/> .
 
-bag_pnd:123 a bag:Pand ;
-  bag:identificatiecode "123" ;
-  bag:status bag_beg:PandInGebruik ;
-  bag:oorspronkelijkBouwjaar 1984 ;
-  bag:beginGeldigheid "2013-09-06T00:00:00.000+02:00"^^xsd:dateTime ;
-.
+{
+	brewery_id:1 a dbeer:Brewery ;
+	    dbeer:id "1" ;
+		dbeer:brewmasters "Jeroen van Hees" ;
+		dbeer:founded "2014" ;
+		dbeer:group "Onafhankelijk" ;
+		dbeer:owners "J.v.Hees" , "I.Verhoef" , "L.du Clou" , "M.Kuijpers" ;
+		schema:state "Zuid-Holland" ;
+		schema:address _:b1 ;
+		schema:email "bier@brouwerij1923.nl" ;
+		schema:name "Brouwerij 1923" ;
+		schema:taxID "61195251" ;
+		schema:telephone "06-10816700" ;
+		schema:url <http://www.brouwerij1923.nl> .
 
-bag_pnd:456 a bag:Pand ;
-  bag:identificatiecode "456" ;
-  bag:status bag_beg:PandGesloopt ;
-  bag:oorspronkelijkBouwjaar 1928 ;
-  bag:beginGeldigheid "2014-09-04T00:00:00.000+01:00"^^xsd:dateTime ;
-  bag:eindGeldigheid "2014-10-06T00:00:00.000+01:00"^^xsd:dateTime ;
-.
+	_:b1 dbeer:bagAdresseerbaarobject <https://bag.basisregistraties.overheid.nl/bag/id/verblijfsobject/1892010000687950> ;
+		dbeer:bagNummeraanduiding <https://bag.basisregistraties.overheid.nl/bag/id/nummeraanduiding/1892200000687949> ;
+		schema:addressLocality "Moordrecht" ;
+		schema:latitude "51.98776545" ;
+		schema:longitude "4.67090183" ;
+		schema:postalCode "2841 XB" ;
+		schema:streetAddress "Burgemeester Brandtstraat 23" .
+
+	brewery_id:2 a dbeer:Brewery ;
+	    dbeer:id "2" ;
+		dbeer:address _:b3 ;
+		dbeer:founded "2017" ;
+		dbeer:group "Onafhankelijk" ;
+		schema:state "Noord-Brabant" ;
+		schema:address _:b4 ;
+		schema:email "info@58egenot.nl" ;
+		schema:name "Brouwerij Het 58e Genot i.o." ;
+		schema:taxID "67452701" ;
+		schema:url <http://www.58egenot.nl> .
+
+	_:b3 dbeer:bagAdresseerbaarobject <https://bag.basisregistraties.overheid.nl/bag/id/verblijfsobject/0879010000008304> ;
+		dbeer:bagNummeraanduiding <https://bag.basisregistraties.overheid.nl/bag/id/nummeraanduiding/0879200000008304> ;
+		schema:addressLocality "Zundert" ;
+		schema:latitude "51.46376967" ;
+		schema:longitude "4.60958924" ;
+		schema:postalCode "4881 AZ" ;
+		schema:streetAddress "Achtmaalseweg 137A" .
+
+	_:b4 schema:postalCode "4881 AZ" ;
+		schema:streetAddress "Achtmaalseweg 137A" .
+
+	brewery_id:3 a dbeer:Brewery ;
+		dbeer:id "3" ;
+		dbeer:annualproduction "140000 hl." ;
+		dbeer:brewmasters "Erik Bielders" ;
+		dbeer:fax "046-4432835" ;
+		dbeer:founded "1870" ;
+		dbeer:group "Onafhankelijk" ;
+		dbeer:openinghours "Alle dagen van de week op aanvraag (12.30-16.00 uur)" ;
+		dbeer:owners "Harry Meens" ;
+		schema:state "Limburg" ;
+		schema:address _:b6 ;
+		schema:name "Alfa Brouwerij" ;
+		schema:taxID "14034012" ;
+		schema:telephone "046-4432888" ;
+		schema:url <http://www.alfabier.nl> .
+
+	_:b6 dbeer:bagAdresseerbaarobject <https://bag.basisregistraties.overheid.nl/bag/id/verblijfsobject/0962010000220594> ;
+		dbeer:bagNummeraanduiding <https://bag.basisregistraties.overheid.nl/bag/id/nummeraanduiding/0962200000220593> ;
+		schema:addressLocality "Schinnen" ;
+		schema:latitude "50.93621081" ;
+		schema:longitude "5.89316555" ;
+		schema:postalCode "6365 AC" ;
+		schema:streetAddress "Thull 15" .
+
+	brewery_id:4 a dbeer:Brewery ;
+	    dbeer:id "4" ;
+		dbeer:brewmasters "Max Schreuder" , "Yvonne van Breda" ;
+		dbeer:founded "2014" ;
+		dbeer:group "Onafhankelijk" ;
+		dbeer:owners "Max Schreuder" , "Yvonne van Breda" ;
+		schema:state "Limburg" ;
+		schema:address _:b8 ;
+		schema:email "info@ambrass.nl" ;
+		schema:name "Ambrass Bierbrouwerij" ;
+		schema:taxID "52966534" ;
+		schema:telephone "046-4009300" ;
+		schema:url <http://www.ambrass.nl> .
+
+	_:b8 dbeer:bagAdresseerbaarobject <https://bag.basisregistraties.overheid.nl/bag/id/verblijfsobject/1883010000004074> ;
+		dbeer:bagNummeraanduiding <https://bag.basisregistraties.overheid.nl/bag/id/nummeraanduiding/1883200000004074> ;
+		schema:addressLocality "Sittard" ;
+		schema:latitude "50.99279662" ;
+		schema:longitude "5.86118305" ;
+		schema:postalCode "6133 WZ" ;
+		schema:streetAddress "Berkenlaan 8" .
+
+	brewery_id:5 a dbeer:Brewery ;
+		dbeer:id "5" ;
+		dbeer:brewmasters "Doeke Visser" ;
+		dbeer:founded "2008" ;
+		dbeer:group "Onafhankelijk" ;
+		dbeer:openinghours "Bezoek op afspraak." ;
+		dbeer:owners "Doeke" , "Eva Visser" ;
+		schema:state "Friesland" ;
+		schema:address _:b10 ;
+		schema:email "info@amelanderbier.nl" ;
+		schema:name "Amelander Bierbrouwerij" ;
+		schema:taxID "01138714" ;
+		schema:telephone "0519-554365" ;
+		schema:url <http://www.amelanderbier.nl> .
+
+	_:b10 dbeer:bagAdresseerbaarobject <https://bag.basisregistraties.overheid.nl/bag/id/verblijfsobject/0060010000131142> ;
+		dbeer:bagNummeraanduiding <https://bag.basisregistraties.overheid.nl/bag/id/nummeraanduiding/0060200000131141> ;
+		schema:addressLocality "Ballum" ;
+		schema:latitude "53.44025996" ;
+		schema:longitude "5.70644929" ;
+		schema:postalCode "9162 EC" ;
+		schema:streetAddress "Smitteweg 6" .
+}

--- a/example/src/main/resources/config/model/shapes.trig
+++ b/example/src/main/resources/config/model/shapes.trig
@@ -1,85 +1,64 @@
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-@prefix bag: <http://bag.basisregistraties.overheid.nl/def/bag#> .
-@prefix bag_sh: <http://bag.basisregistraties.overheid.nl/def/bag/> .
+@prefix schema: <http://schema.org/> .
+@prefix dbeer: <http://dbeerpedia.com/def#> .
+@prefix dbeer_sh: <http://dbeerpedia.com/def/> .
 
-<http://bag.basisregistraties.overheid.nl/bag/id/shapes/imbag> {
-  bag_sh:Pand a sh:NodeShape ;
-    sh:targetClass bag:Pand ;
+<http://dbeerpedia.com/id/shapes> {
+  dbeer_sh:Brewery a sh:NodeShape ;
+    sh:targetClass dbeer:Brewery ;
     sh:property
-      bag_sh:Pand_identificatiecode ,
-      bag_sh:Pand_status ,
-      bag_sh:Pand_oorspronkelijkBouwjaar ,
-      bag_sh:Pand_beginGeldigheid ,
-      bag_sh:Pand_eindGeldigheid ;
+      dbeer_sh:Brewery_id ,
+      dbeer_sh:Brewery_name ,
+      dbeer_sh:Brewery_founded ,
+      dbeer_sh:Brewery_openinghours ,
+      dbeer_sh:Brewery_url ;
   .
 
-  bag_sh:Pand_identificatiecode a sh:PropertyShape ;
-    sh:name "identificatiecode" ;
-    sh:path bag:identificatiecode ;
+  dbeer_sh:Brewery_id a sh:PropertyShape ;
+    sh:name "id" ;
+    sh:path dbeer:id ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
     sh:nodeKind sh:Literal ;
     sh:datatype xsd:string ;
   .
 
-  bag_sh:Pand_status a sh:PropertyShape ;
-    sh:name "status" ;
-    sh:path bag:status ;
+  dbeer_sh:Brewery_name a sh:PropertyShape ;
+    sh:name "name" ;
+    sh:path schema:name ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
     sh:nodeKind sh:IRI ;
   .
 
-  bag_sh:Pand_oorspronkelijkBouwjaar a sh:PropertyShape ;
-    sh:name "oorspronkelijkBouwjaar" ;
-    sh:path bag:oorspronkelijkBouwjaar ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-    sh:nodeKind sh:Literal ;
-    sh:datatype xsd:short ;
-  .
+   dbeer_sh:Brewery_founded a sh:PropertyShape ;
+      sh:name "founded" ;
+      sh:path dbeer:founded ;
+      sh:minCount 1 ;
+      sh:maxCount 1 ;
+      sh:nodeKind sh:Literal ;
+      sh:datatype xsd:string ;
+    .
 
-  bag_sh:Pand_beginGeldigheid a sh:PropertyShape ;
-    sh:name "beginGeldigheid" ;
-    sh:path bag:beginGeldigheid ;
-    sh:minCount 1 ;
-    sh:maxCount 1 ;
-    sh:nodeKind sh:Literal ;
-    sh:datatype xsd:datetime ;
-  .
-
-  bag_sh:Pand_eindGeldigheid a sh:PropertyShape ;
-    sh:name "eindGeldigheid" ;
-    sh:path bag:eindGeldigheid ;
-    sh:minCount 0 ;
-    sh:maxCount 1 ;
-    sh:nodeKind sh:Literal ;
-    sh:datatype xsd:datetime ;
-  .
-
-  bag_sh:Verblijfsobject a sh:NodeShape ;
-    sh:targetClass bag:Verblijfsobject ;
-    sh:property
-      bag_sh:Verblijfsobject_identificatiecode ,
-      bag_sh:Verblijfsobject_status ;
-  .
-
-  bag_sh:Verblijfsobject_identificatiecode a sh:PropertyShape ;
-    sh:name "identificatiecode" ;
-    sh:path bag:identificatiecode ;
+ dbeer_sh:Brewery_openinghours a sh:PropertyShape ;
+    sh:name "openinghours" ;
+    sh:path dbeer:openinghours ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
     sh:nodeKind sh:Literal ;
     sh:datatype xsd:string ;
   .
 
-  bag_sh:Verblijfsobject_status a sh:PropertyShape ;
-    sh:name "status" ;
-    sh:path bag:status ;
+ dbeer_sh:Brewery_url a sh:PropertyShape ;
+    sh:name "url" ;
+    sh:path schema:url ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
-    sh:nodeKind sh:IRI ;
+    sh:nodeKind sh:Literal ;
+    sh:datatype xsd:string ;
   .
+
+
 }

--- a/example/src/main/resources/config/model/shapes.trig
+++ b/example/src/main/resources/config/model/shapes.trig
@@ -2,30 +2,31 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 @prefix schema: <http://schema.org/> .
-@prefix dbeer: <http://dbeerpedia.com/def#> .
-@prefix dbeer_sh: <http://dbeerpedia.com/def/> .
+@prefix beer: <https://github.com/dotwebstack/beer/> .
+@prefix beer_def: <https://github.com/dotwebstack/beer/def#> .
+@prefix beer_sh: <https://github.com/dotwebstack/beer/shapes#> .
 
-<http://dbeerpedia.com/id/shapes> {
-  dbeer_sh:Brewery a sh:NodeShape ;
-    sh:targetClass dbeer:Brewery ;
+<https://github.com/dotwebstack/beer/shapes> {
+  beer_sh:Brewery a sh:NodeShape ;
+    sh:targetClass beer_def:Brewery ;
     sh:property
-      dbeer_sh:Brewery_id ,
-      dbeer_sh:Brewery_name ,
-      dbeer_sh:Brewery_founded ,
-      dbeer_sh:Brewery_openinghours ,
-      dbeer_sh:Brewery_url ;
+      beer_sh:Brewery_identifier ,
+      beer_sh:Brewery_name ,
+      beer_sh:Brewery_founded ,
+      beer_sh:Brewery_openinghours ,
+      beer_sh:Brewery_url ;
   .
 
-  dbeer_sh:Brewery_id a sh:PropertyShape ;
-    sh:name "id" ;
-    sh:path dbeer:id ;
+  beer_sh:Brewery_identifier a sh:PropertyShape ;
+    sh:name "identifier" ;
+    sh:path beer_def:identifier ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
     sh:nodeKind sh:Literal ;
     sh:datatype xsd:string ;
   .
 
-  dbeer_sh:Brewery_name a sh:PropertyShape ;
+  beer_sh:Brewery_name a sh:PropertyShape ;
     sh:name "name" ;
     sh:path schema:name ;
     sh:minCount 1 ;
@@ -33,25 +34,25 @@
     sh:nodeKind sh:IRI ;
   .
 
-   dbeer_sh:Brewery_founded a sh:PropertyShape ;
+   beer_sh:Brewery_founded a sh:PropertyShape ;
       sh:name "founded" ;
-      sh:path dbeer:founded ;
+      sh:path beer_def:founded ;
       sh:minCount 1 ;
       sh:maxCount 1 ;
       sh:nodeKind sh:Literal ;
-      sh:datatype xsd:string ;
+      sh:datatype xsd:dateTime ;
     .
 
- dbeer_sh:Brewery_openinghours a sh:PropertyShape ;
+ beer_sh:Brewery_openinghours a sh:PropertyShape ;
     sh:name "openinghours" ;
-    sh:path dbeer:openinghours ;
+    sh:path beer_def:openinghours ;
     sh:minCount 1 ;
     sh:maxCount 1 ;
     sh:nodeKind sh:Literal ;
     sh:datatype xsd:string ;
   .
 
- dbeer_sh:Brewery_url a sh:PropertyShape ;
+ beer_sh:Brewery_url a sh:PropertyShape ;
     sh:name "url" ;
     sh:path schema:url ;
     sh:minCount 1 ;

--- a/example/src/main/resources/config/schema.graphqls
+++ b/example/src/main/resources/config/schema.graphqls
@@ -3,10 +3,10 @@ schema {
 }
 
 type Query {
-  brewery(id: ID!): Brewery
+  brewery(identifier: ID!): Brewery
     @sparql(
       repository: "local",
-      subject: "http://dbeerpedia.com/id/brewery/${id}")
+      subject: "https://github.com/dotwebstack/beer/id/brewery/${identifier}")
   breweries(page: Int = 1, pageSize: Int = 10): [Brewery!]!
     @sparql(
       repository: "local",
@@ -22,11 +22,13 @@ type Query {
 }
 
 type Brewery {
-  id: ID!
+  identifier: ID!
   name: String!
   founded: String!
+    @transform(expr: "founded.calendarValue().getYear()")
   openinghours: String
   url: String!
+    @transform(expr: "url.getLocalName()")
 }
 
 input CollectionQueryInput {

--- a/example/src/main/resources/config/schema.graphqls
+++ b/example/src/main/resources/config/schema.graphqls
@@ -3,17 +3,17 @@ schema {
 }
 
 type Query {
-  pand(identificatiecode: ID!): Pand
+  brewery(id: ID!): Brewery
     @sparql(
       repository: "local",
-      subject: "http://bag.basisregistraties.overheid.nl/bag/id/pand/${identificatiecode}")
-  panden(page: Int = 1, pageSize: Int = 10): [Pand!]!
+      subject: "http://dbeerpedia.com/id/brewery/${id}")
+  breweries(page: Int = 1, pageSize: Int = 10): [Brewery!]!
     @sparql(
       repository: "local",
       limit: "pageSize",
       offset: "(page - 1) * pageSize"
     )
-  panden_from_input(input: CollectionQueryInput): [Pand!]!
+  breweries_from_input(input: CollectionQueryInput): [Brewery!]!
     @sparql(
       repository: "local",
       limit: "input.pageSize",
@@ -21,18 +21,12 @@ type Query {
     )
 }
 
-type Pand {
-  identificatiecode: ID!
-  status: String!
-    @transform(expr: "status.getLocalName()")
-  oorspronkelijkBouwjaar: Int!
-  beginGeldigheid: DateTime!
-  eindGeldigheid: DateTime
-}
-
-type Verblijfsobject {
-  identificatiecode: ID!
-  status: String!
+type Brewery {
+  id: ID!
+  name: String!
+  founded: String!
+  openinghours: String
+  url: String!
 }
 
 input CollectionQueryInput {


### PR DESCRIPTION
Use beer ontology for unit and integration tests. 

The implemented ontology is inspired by Dbeerpedia but changed at some points. 
- Object and property names in english
- Named graphs
- The current ontology holds breweries and direct related information. In a later stage we can expand the ontology with beers and ingredients. 