### PR TITLE
KDP-7008 - Improvements for uri-dereferencing

### DIFF
--- a/backend/rdf4j/src/main/java/org/dotwebstack/framework/backend/rdf4j/query/StaticQueryFetcher.java
+++ b/backend/rdf4j/src/main/java/org/dotwebstack/framework/backend/rdf4j/query/StaticQueryFetcher.java
@@ -41,6 +41,8 @@ public final class StaticQueryFetcher implements DataFetcher<Object> {
 
   private static final ValueFactory VF = SimpleValueFactory.getInstance();
 
+  private static final String SUBJECT = "subject";
+
   private static final List<GraphQLScalarType> SUPPORTED_TYPE_NAMES =
       Arrays.asList(Rdf4jScalars.IRI, Rdf4jScalars.MODEL);
 
@@ -149,7 +151,7 @@ public final class StaticQueryFetcher implements DataFetcher<Object> {
         DirectiveUtils.getArgument(sparqlDirective, Rdf4jDirectives.SPARQL_ARG_SUBJECT, String.class);
 
     if (subjectTemplate != null) {
-      query.setBinding("subject", VF.createIRI(new StringSubstitutor(queryParameters).replace(subjectTemplate)));
+      query.setBinding(SUBJECT, VF.createIRI(new StringSubstitutor(queryParameters).replace(subjectTemplate)));
     } else {
       queryParameters.forEach((key, value) -> {
 

--- a/core/src/main/java/org/dotwebstack/framework/core/jexl/JexlHelper.java
+++ b/core/src/main/java/org/dotwebstack/framework/core/jexl/JexlHelper.java
@@ -26,6 +26,8 @@ public class JexlHelper {
 
   private static final String ARGUMENT_PREFIX = "args.";
 
+  private static final String FIELDS_PREFIX = "fields.";
+
   private final JexlEngine engine;
 
   public JexlHelper(@NonNull JexlEngine engine) {
@@ -33,11 +35,11 @@ public class JexlHelper {
   }
 
   public static JexlContext getJexlContext(Map<String, String> envParams, Map<String, Object> argParams) {
-    return getJexlContext(envParams, argParams, null);
+    return getJexlContext(envParams, argParams, null, null);
   }
 
   public static JexlContext getJexlContext(Map<String, String> envParams, Map<String, Object> argParams,
-      GraphQlField graphQlField) {
+      GraphQlField graphQlField, Map<String, Object> resultData) {
     JexlContext jexlContext = new MapContext();
 
     if (Objects.nonNull(envParams)) {
@@ -50,6 +52,13 @@ public class JexlHelper {
           .filter(argument -> Objects.nonNull(argument.getDefaultValue()))
           .forEach(argument -> jexlContext.set(ARGUMENT_PREFIX + argument.getName(),
               GraphQlValueHelper.getValue(argument.getType(), argument.getDefaultValue())));
+    }
+
+    if (resultData != null) {
+      resultData.entrySet()
+          .stream()
+          .filter(entry -> !(entry.getValue() instanceof Map))
+          .forEach(entry -> jexlContext.set(FIELDS_PREFIX + entry.getKey(), entry.getValue()));
     }
 
     if (Objects.nonNull(argParams)) {

--- a/core/src/main/java/org/dotwebstack/framework/core/jexl/JexlHelper.java
+++ b/core/src/main/java/org/dotwebstack/framework/core/jexl/JexlHelper.java
@@ -42,11 +42,11 @@ public class JexlHelper {
       GraphQlField graphQlField, Map<String, Object> resultData) {
     JexlContext jexlContext = new MapContext();
 
-    if (Objects.nonNull(envParams)) {
+    if (envParams != null) {
       envParams.forEach((key, value) -> jexlContext.set(ENVIRONMENT_PREFIX + key, value));
     }
 
-    if (Objects.nonNull(graphQlField)) {
+    if (graphQlField != null) {
       graphQlField.getArguments()
           .stream()
           .filter(argument -> Objects.nonNull(argument.getDefaultValue()))
@@ -61,7 +61,7 @@ public class JexlHelper {
           .forEach(entry -> jexlContext.set(FIELDS_PREFIX + entry.getKey(), entry.getValue()));
     }
 
-    if (Objects.nonNull(argParams)) {
+    if (argParams != null) {
       argParams.forEach((key, value) -> jexlContext.set(ARGUMENT_PREFIX + key, value.toString()));
     }
 

--- a/core/src/test/java/org/dotwebstack/framework/core/jexl/JexlHelperTest.java
+++ b/core/src/test/java/org/dotwebstack/framework/core/jexl/JexlHelperTest.java
@@ -235,7 +235,7 @@ public class JexlHelperTest {
             .build()))
         .build();
 
-    JexlContext context = JexlHelper.getJexlContext(null, null, graphQlField);
+    JexlContext context = JexlHelper.getJexlContext(null, null, graphQlField, null);
 
     assertEquals("1", context.get("args.value"));
   }

--- a/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/OpenApiConfiguration.java
+++ b/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/OpenApiConfiguration.java
@@ -170,11 +170,11 @@ public class OpenApiConfiguration {
 
     List<ResponseTemplate> responseTemplates = responseTemplateBuilder.buildResponseTemplates(httpMethodOperation);
 
-    GraphQlField graphQlField = queryFieldHelper.resolveGraphQlField(httpMethodOperation.getOperation());
+    Optional<GraphQlField> graphQlField = queryFieldHelper.resolveGraphQlField(httpMethodOperation.getOperation());
     List<String> requiredFields = DwsExtensionHelper.getDwsRequiredFields(httpMethodOperation.getOperation());
 
     ResponseSchemaContext responseSchemaContext = ResponseSchemaContext.builder()
-        .graphQlField(graphQlField)
+        .graphQlField(graphQlField.orElse(null))
         .requiredFields(Objects.nonNull(requiredFields) ? requiredFields : Collections.emptyList())
         .responses(responseTemplates)
         .parameters(httpMethodOperation.getOperation()

--- a/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/helper/DwsExtensionHelper.java
+++ b/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/helper/DwsExtensionHelper.java
@@ -1,6 +1,7 @@
 package org.dotwebstack.framework.service.openapi.helper;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static org.dotwebstack.framework.service.openapi.helper.OasConstants.X_DWS_ENVELOPE;
 import static org.dotwebstack.framework.service.openapi.helper.OasConstants.X_DWS_EXPR;
 import static org.dotwebstack.framework.service.openapi.helper.OasConstants.X_DWS_QUERY;
@@ -15,7 +16,6 @@ import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.parameters.RequestBody;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,37 +37,37 @@ public class DwsExtensionHelper {
 
   public static boolean supportsDwsType(@NonNull Parameter parameter, @NonNull String typeString) {
     Map<String, Object> extensions = parameter.getExtensions();
-    return Objects.nonNull(extensions) && supportsDwsType(typeString, extensions);
+    return extensions != null && supportsDwsType(typeString, extensions);
   }
 
   public static boolean supportsDwsType(@NonNull RequestBody requestBody, @NonNull String typeString) {
     Map<String, Object> extensions = requestBody.getExtensions();
-    return Objects.nonNull(extensions) && supportsDwsType(typeString, extensions);
+    return extensions != null && supportsDwsType(typeString, extensions);
   }
 
   private static boolean supportsDwsType(String typeString, Map<String, Object> extensions) {
     String handler = (String) extensions.get(X_DWS_TYPE);
-    return (Objects.nonNull(handler)) && Objects.equals(handler, typeString);
+    return (handler != null) && handler.equals(typeString);
   }
 
   public static boolean hasDwsExtensionWithValue(@NonNull Parameter parameter, @NonNull String typeName,
       @NonNull Object value) {
     Map<String, Object> extensions = parameter.getExtensions();
-    return (Objects.nonNull(extensions)) && Objects.equals(value, extensions.get(typeName));
+    return (extensions != null) && value.equals(extensions.get(typeName));
   }
 
   public static Object getDwsExtension(@NonNull Schema<?> schema, @NonNull String typeName) {
     Map<String, Object> extensions = schema.getExtensions();
-    return (Objects.nonNull(extensions)) ? extensions.get(typeName) : null;
+    return (extensions != null) ? extensions.get(typeName) : null;
   }
 
   private static boolean isExpr(@NonNull Schema<?> schema) {
-    return Objects.nonNull(getDwsExtension(schema, X_DWS_EXPR));
+    return getDwsExtension(schema, X_DWS_EXPR) != null;
   }
 
   public static boolean isEnvelope(@NonNull Schema<?> schema) {
     Boolean isEnvelope = (Boolean) getDwsExtension(schema, X_DWS_ENVELOPE);
-    return (Objects.nonNull(isEnvelope) && isEnvelope) || isExpr(schema);
+    return (isEnvelope != null && isEnvelope) || isExpr(schema);
   }
 
   public static Optional<String> getDwsQueryName(@NonNull Operation operation) {
@@ -99,7 +99,7 @@ public class DwsExtensionHelper {
 
   public static Map<String, String> getDwsQueryParameters(@NonNull Operation operation) {
     if (operation.getExtensions() == null) {
-      return Collections.emptyMap();
+      return emptyMap();
     }
 
     Map<String, String> result = new HashMap<>();

--- a/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/helper/QueryFieldHelper.java
+++ b/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/helper/QueryFieldHelper.java
@@ -1,12 +1,14 @@
 package org.dotwebstack.framework.service.openapi.helper;
 
 import static org.dotwebstack.framework.core.helpers.ExceptionHelper.invalidConfigurationException;
+import static org.dotwebstack.framework.service.openapi.helper.DwsExtensionHelper.getDwsQueryName;
 
 import graphql.language.FieldDefinition;
 import graphql.language.ObjectTypeDefinition;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import io.swagger.v3.oas.models.Operation;
 import java.util.HashMap;
+import java.util.Optional;
 import lombok.Builder;
 import lombok.NonNull;
 import org.dotwebstack.framework.core.query.GraphQlField;
@@ -19,11 +21,9 @@ public class QueryFieldHelper {
 
   private GraphQlFieldBuilder graphQlFieldBuilder;
 
-  public GraphQlField resolveGraphQlField(@NonNull Operation operation) {
-    String dwsQuery = DwsExtensionHelper.getDwsQueryName(operation);
-    FieldDefinition queryFieldDefinition = getQueryFieldDefinition(dwsQuery);
-
-    return this.graphQlFieldBuilder.toGraphQlField(queryFieldDefinition, new HashMap<>());
+  public Optional<GraphQlField> resolveGraphQlField(@NonNull Operation operation) {
+    return getDwsQueryName(operation).map(this::getQueryFieldDefinition)
+        .map(queryFieldDefinition -> this.graphQlFieldBuilder.toGraphQlField(queryFieldDefinition, new HashMap<>()));
   }
 
   private FieldDefinition getQueryFieldDefinition(String dwsQuery) {

--- a/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/mapping/JsonResponseMapper.java
+++ b/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/mapping/JsonResponseMapper.java
@@ -267,7 +267,8 @@ public class JsonResponseMapper {
 
   @SuppressWarnings("unchecked")
   private Optional<String> evaluateJexl(ResponseWriteContext writeContext) {
-    JexlContext context = JexlHelper.getJexlContext(null, writeContext.getParameters(), writeContext.getGraphQlField());
+    JexlContext context =
+        JexlHelper.getJexlContext(null, writeContext.getParameters(), writeContext.getGraphQlField(), null);
 
     // add object data to context
     writeContext.getParameters()

--- a/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/query/GraphQlQueryBuilder.java
+++ b/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/query/GraphQlQueryBuilder.java
@@ -6,6 +6,7 @@ import static org.dotwebstack.framework.service.openapi.response.ResponseContext
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 import lombok.NonNull;
@@ -14,8 +15,13 @@ import org.dotwebstack.framework.service.openapi.response.ResponseSchemaContext;
 
 public class GraphQlQueryBuilder {
 
-  public String toQuery(@NonNull ResponseSchemaContext responseSchemaContext,
+  public Optional<String> toQuery(@NonNull ResponseSchemaContext responseSchemaContext,
       @NonNull Map<String, Object> inputParams) {
+
+    if (responseSchemaContext.getGraphQlField() == null) {
+      return Optional.empty();
+    }
+
     Set<String> requiredPaths = getPathsForSuccessResponse(responseSchemaContext, inputParams);
 
     StringBuilder builder = new StringBuilder();
@@ -31,7 +37,7 @@ public class GraphQlQueryBuilder {
       builder.append(")");
     }
     builder.append(joiner.toString());
-    return builder.toString();
+    return Optional.of(builder.toString());
   }
 
   protected void addToQuery(GraphQlField field, Set<String> requiredPaths, StringJoiner joiner,

--- a/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/response/ResponseContextHelper.java
+++ b/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/response/ResponseContextHelper.java
@@ -25,7 +25,7 @@ public class ResponseContextHelper {
       @NonNull Map<String, Object> inputParams) {
     Optional<ResponseTemplate> successResponse = responseSchemaContext.getResponses()
         .stream()
-        .filter(template -> template.isApplicable(200, 299))
+        .filter(template -> template.isApplicable(200, 299) || template.isApplicable(300, 303))
         .findFirst();
 
     if (successResponse.isPresent()) {

--- a/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/response/ResponseTemplateBuilder.java
+++ b/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/response/ResponseTemplateBuilder.java
@@ -2,6 +2,7 @@ package org.dotwebstack.framework.service.openapi.response;
 
 import static org.dotwebstack.framework.core.helpers.ExceptionHelper.invalidConfigurationException;
 import static org.dotwebstack.framework.service.openapi.helper.DwsExtensionHelper.getDwsExtension;
+import static org.dotwebstack.framework.service.openapi.helper.DwsExtensionHelper.getDwsQueryName;
 import static org.dotwebstack.framework.service.openapi.helper.DwsExtensionHelper.getDwsType;
 import static org.dotwebstack.framework.service.openapi.helper.DwsExtensionHelper.isEnvelope;
 import static org.dotwebstack.framework.service.openapi.helper.OasConstants.X_DWS_EXPR;
@@ -32,7 +33,6 @@ import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.NonNull;
 import org.dotwebstack.framework.service.openapi.HttpMethodOperation;
-import org.dotwebstack.framework.service.openapi.helper.DwsExtensionHelper;
 import org.dotwebstack.framework.service.openapi.helper.OasConstants;
 
 @Builder
@@ -58,7 +58,7 @@ public class ResponseTemplateBuilder {
         .entrySet()
         .stream()
         .flatMap(entry -> createResponses(openApi, entry.getKey(), entry.getValue(),
-            DwsExtensionHelper.getDwsQueryName(httpMethodOperation.getOperation())).stream())
+            getDwsQueryName(httpMethodOperation.getOperation()).orElse(null)).stream())
         .collect(Collectors.toList());
   }
 

--- a/service/openapi/src/test/java/org/dotwebstack/framework/service/openapi/OpenApiConfigurationTest.java
+++ b/service/openapi/src/test/java/org/dotwebstack/framework/service/openapi/OpenApiConfigurationTest.java
@@ -159,14 +159,14 @@ public class OpenApiConfigurationTest {
     openApiConfiguration.route(openApi);
 
     // Assert
-    assertEquals(8, optionsAnswer.getResults()
+    assertEquals(11, optionsAnswer.getResults()
         .size()); // Assert OPTIONS route
 
-    verify(this.openApiConfiguration, times(9)).toRouterFunctions(any(ResponseTemplateBuilder.class),
+    verify(this.openApiConfiguration, times(12)).toRouterFunctions(any(ResponseTemplateBuilder.class),
         any(RequestBodyContextBuilder.class), argumentCaptor.capture());
 
     List<HttpMethodOperation> actualHttpMethodOperations = argumentCaptor.getAllValues();
-    assertEquals(9, actualHttpMethodOperations.size());
+    assertEquals(12, actualHttpMethodOperations.size());
 
     assertEquals(HttpMethod.GET, actualHttpMethodOperations.get(0)
         .getHttpMethod());

--- a/service/openapi/src/test/java/org/dotwebstack/framework/service/openapi/helper/DwsExtensionHelperTest.java
+++ b/service/openapi/src/test/java/org/dotwebstack/framework/service/openapi/helper/DwsExtensionHelperTest.java
@@ -12,10 +12,10 @@ import org.dotwebstack.framework.service.openapi.TestResources;
 import org.junit.jupiter.api.Test;
 
 
-public class DwsExtensionHelperTest {
+class DwsExtensionHelperTest {
 
   @Test
-  public void getDwsQueryName_returnsQueryName_whenShortForm() {
+  void getDwsQueryName_returnsQueryName_whenShortForm() {
     // Arrange
     Operation getShortForm = TestResources.openApi()
         .getPaths()
@@ -27,7 +27,7 @@ public class DwsExtensionHelperTest {
   }
 
   @Test
-  public void getDwsQueryName_returnsField_whenAdvancedForm() {
+  void getDwsQueryName_returnsField_whenAdvancedForm() {
     // Arrange
     Operation getAdvancedForm = TestResources.openApi()
         .getPaths()
@@ -39,7 +39,7 @@ public class DwsExtensionHelperTest {
   }
 
   @Test
-  public void getDwsQueryParameters_returnsParameters_whenSpecified() {
+  void getDwsQueryParameters_returnsParameters_whenSpecified() {
     // Arrange
     Operation getWithDwsParameters = TestResources.openApi()
         .getPaths()
@@ -63,7 +63,7 @@ public class DwsExtensionHelperTest {
         .getGet();
 
     // Act / Assert
-    assertEquals(getDwsQueryParameters(getWithoutDwsParameters), emptyMap());
+    assertEquals(emptyMap(), getDwsQueryParameters(getWithoutDwsParameters));
   }
 
   @Test
@@ -75,6 +75,6 @@ public class DwsExtensionHelperTest {
         .getGet();
 
     // Act / Assert
-    assertEquals(getDwsQueryParameters(getShortForm), emptyMap());
+    assertEquals(emptyMap(), getDwsQueryParameters(getShortForm));
   }
 }

--- a/service/openapi/src/test/java/org/dotwebstack/framework/service/openapi/helper/DwsExtensionHelperTest.java
+++ b/service/openapi/src/test/java/org/dotwebstack/framework/service/openapi/helper/DwsExtensionHelperTest.java
@@ -1,10 +1,13 @@
 package org.dotwebstack.framework.service.openapi.helper;
 
+import static java.util.Collections.emptyMap;
+import static org.dotwebstack.framework.service.openapi.helper.DwsExtensionHelper.getDwsQueryName;
+import static org.dotwebstack.framework.service.openapi.helper.DwsExtensionHelper.getDwsQueryParameters;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.swagger.v3.oas.models.Operation;
-import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import org.dotwebstack.framework.service.openapi.TestResources;
 import org.junit.jupiter.api.Test;
 
@@ -20,7 +23,7 @@ public class DwsExtensionHelperTest {
         .getGet();
 
     // Act / Assert
-    assertEquals(DwsExtensionHelper.getDwsQueryName(getShortForm), "query1");
+    assertEquals(getDwsQueryName(getShortForm), Optional.of("query1"));
   }
 
   @Test
@@ -32,7 +35,7 @@ public class DwsExtensionHelperTest {
         .getGet();
 
     // Act / Assert
-    assertEquals(DwsExtensionHelper.getDwsQueryName(getAdvancedForm), "query2");
+    assertEquals(getDwsQueryName(getAdvancedForm), Optional.of("query2"));
   }
 
   @Test
@@ -44,7 +47,7 @@ public class DwsExtensionHelperTest {
         .getGet();
 
     // Act
-    Map<String, String> dwsParameters = DwsExtensionHelper.getDwsQueryParameters(getWithDwsParameters);
+    Map<String, String> dwsParameters = getDwsQueryParameters(getWithDwsParameters);
 
     // Assert
     assertEquals(dwsParameters.size(), 1);
@@ -60,7 +63,7 @@ public class DwsExtensionHelperTest {
         .getGet();
 
     // Act / Assert
-    assertEquals(DwsExtensionHelper.getDwsQueryParameters(getWithoutDwsParameters), Collections.emptyMap());
+    assertEquals(getDwsQueryParameters(getWithoutDwsParameters), emptyMap());
   }
 
   @Test
@@ -72,6 +75,6 @@ public class DwsExtensionHelperTest {
         .getGet();
 
     // Act / Assert
-    assertEquals(DwsExtensionHelper.getDwsQueryParameters(getShortForm), Collections.emptyMap());
+    assertEquals(getDwsQueryParameters(getShortForm), emptyMap());
   }
 }

--- a/service/openapi/src/test/java/org/dotwebstack/framework/service/openapi/helper/DwsExtensionHelperTest.java
+++ b/service/openapi/src/test/java/org/dotwebstack/framework/service/openapi/helper/DwsExtensionHelperTest.java
@@ -188,6 +188,19 @@ class DwsExtensionHelperTest {
   }
 
   @Test
+  void supportsDwsType_returnsFalse_forRequestBodyWithDwsTypeMismatch() {
+    // Arrange
+    RequestBody requestBody = TestResources.openApi()
+        .getPaths()
+        .get("/query11")
+        .getPost()
+        .getRequestBody();
+
+    // Act / Assert
+    assertFalse(supportsDwsType(requestBody, "anothertype"));
+  }
+
+  @Test
   void supportsDwsType_returnsTrue_forParameterWithoutDwsType() {
     // Arrange
     Parameter parameter = TestResources.openApi()
@@ -213,6 +226,20 @@ class DwsExtensionHelperTest {
 
     // Act / Assert
     assertTrue(supportsDwsType(parameter, "specialtype"));
+  }
+
+  @Test
+  void supportsDwsType_returnsFalse_forParameterWithDwsTypeMismatch() {
+    // Arrange
+    Parameter parameter = TestResources.openApi()
+        .getPaths()
+        .get("/query6")
+        .getGet()
+        .getParameters()
+        .get(0);
+
+    // Act / Assert
+    assertFalse(supportsDwsType(parameter, "anothertype"));
   }
 
   @Test

--- a/service/openapi/src/test/java/org/dotwebstack/framework/service/openapi/helper/DwsExtensionHelperTest.java
+++ b/service/openapi/src/test/java/org/dotwebstack/framework/service/openapi/helper/DwsExtensionHelperTest.java
@@ -5,6 +5,7 @@ import static java.util.Collections.emptyMap;
 import static org.dotwebstack.framework.service.openapi.helper.DwsExtensionHelper.getDwsQueryName;
 import static org.dotwebstack.framework.service.openapi.helper.DwsExtensionHelper.getDwsQueryParameters;
 import static org.dotwebstack.framework.service.openapi.helper.DwsExtensionHelper.getDwsRequiredFields;
+import static org.dotwebstack.framework.service.openapi.helper.DwsExtensionHelper.hasDwsExtensionWithValue;
 import static org.dotwebstack.framework.service.openapi.helper.DwsExtensionHelper.isEnvelope;
 import static org.dotwebstack.framework.service.openapi.helper.DwsExtensionHelper.supportsDwsType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -212,5 +213,19 @@ class DwsExtensionHelperTest {
 
     // Act / Assert
     assertTrue(supportsDwsType(parameter, "specialtype"));
+  }
+
+  @Test
+  void hasDwsExtensionWithValue_returnsTrue_forParameterWithDwsType() {
+    // Arrange
+    Parameter parameter = TestResources.openApi()
+        .getPaths()
+        .get("/query6")
+        .getGet()
+        .getParameters()
+        .get(0);
+
+    // Act / Assert
+    assertTrue(hasDwsExtensionWithValue(parameter, OasConstants.X_DWS_TYPE, "specialtype"));
   }
 }

--- a/service/openapi/src/test/java/org/dotwebstack/framework/service/openapi/response/SchemaSummaryContextValidatorTest.java
+++ b/service/openapi/src/test/java/org/dotwebstack/framework/service/openapi/response/SchemaSummaryContextValidatorTest.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.PathItem;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 import org.dotwebstack.framework.core.InvalidConfigurationException;
 import org.dotwebstack.framework.core.query.GraphQlField;
 import org.dotwebstack.framework.service.openapi.TestResources;
@@ -160,11 +161,11 @@ public class SchemaSummaryContextValidatorTest {
     PathItem pathItem = this.openApi.getPaths()
         .get(path);
     List<ResponseTemplate> responses = ResponseTemplateBuilderTest.getResponseTemplates(this.openApi, path, httpMethod);
-    GraphQlField field = TestResources.queryFieldHelper(this.registry)
+    Optional<GraphQlField> field = TestResources.queryFieldHelper(this.registry)
         .resolveGraphQlField(pathItem.getGet());
 
     return ResponseSchemaContext.builder()
-        .graphQlField(field)
+        .graphQlField(field.orElse(null))
         .responses(responses)
         .build();
   }

--- a/service/openapi/src/test/resources/config/model/openapi.yml
+++ b/service/openapi/src/test/resources/config/model/openapi.yml
@@ -221,6 +221,7 @@ paths:
       x-dws-query: query6
       parameters:
         - name: query6_param1
+          x-dws-type: specialtype
           in: query
           schema:
             type: string
@@ -265,3 +266,45 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/Object8'
+  /query9:
+    get:
+      x-dws-query:
+        field: query9
+        requiredFields:
+          - field1
+      responses:
+        200:
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/Object2'
+  /query10:
+    get:
+      responses:
+        303:
+          description: "300 response"
+          headers:
+            Location:
+              schema:
+                type: string
+                x-dws-expr: '`/foo/bar`'
+  /query11:
+    post:
+      x-dws-query: query11
+      requestBody:
+        x-dws-type: specialtype
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                argument1:
+                  type: string
+      responses:
+        200:
+          description: OK
+          content:
+            application/hal+json:
+              schema:
+                $ref: '#/components/schemas/Object1'

--- a/service/openapi/src/test/resources/config/schema.graphqls
+++ b/service/openapi/src/test/resources/config/schema.graphqls
@@ -18,6 +18,10 @@ type Query {
     query7: Object7
 
     query8: Object8
+
+    query9: Object9
+
+    query11(argument1: String): Object11
 }
 
 type Object1 {
@@ -53,4 +57,13 @@ type Object7 {
 
 type Object8 {
   children: [Object8]
+}
+
+type Object9 {
+    field1: String
+    children: [Object9]
+}
+
+type Object11 {
+    children: [Object11]
 }

--- a/templating/pebble-rdf4j/src/test/java/org/dotwebstack/framework/templating/pebble/filter/JsonLdFilterTest.java
+++ b/templating/pebble-rdf4j/src/test/java/org/dotwebstack/framework/templating/pebble/filter/JsonLdFilterTest.java
@@ -15,7 +15,7 @@ import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-public class JsonLdFilterTest {
+class JsonLdFilterTest {
 
   private JsonLdFilter jsonLdFilter;
 
@@ -26,16 +26,16 @@ public class JsonLdFilterTest {
   }
 
   @Test
-  public void applyModelTest() throws IOException {
+  void applyModelTest() throws IOException {
     // Act
     String result = (String) jsonLdFilter.apply(buildModel(), null, null, null, 0);
 
     // Assert
-    assertThat(result, is(new String(getFileInputStream("jsonLdSerialized.txt").readAllBytes())));
+    assertThat(result.replace("\r\n", "\n"), is(new String(getFileInputStream("jsonLdSerialized.txt").readAllBytes())));
   }
 
   @Test
-  public void argumentNamesShouldReturnEmptyList() {
+  void argumentNamesShouldReturnEmptyList() {
     // Act
     List<String> arguments = jsonLdFilter.getArgumentNames();
 


### PR DESCRIPTION
- *x-dws-query*  optional in OAS specification instead of throwing a NullpointerException. (to redirect without query) 
- Execute queries for redirects if *x-dws-query* is specified
- Register result fields in Jexl response header context
- Support *subject* argument with the *sparql* directive if a *queryRef* is supplied. (in this case only the subject value will be binded)