### PR TITLE
[DHUB-3386] Add error handling for graphql-java-orchestrate

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <spring-boot.version>3.1.6</spring-boot.version>
     <rdf4j.version>4.3.8</rdf4j.version>
     <graphql.java.version>21.3</graphql.java.version>
-    <graphql.java.orchestrate.version>0.2.0</graphql.java.orchestrate.version>
+    <graphql.java.orchestrate.version>0.2.1-SNAPSHOT</graphql.java.orchestrate.version>
     <commons.jexl3.version>3.2.1</commons.jexl3.version>
     <commons.text.version>1.11.0</commons.text.version>
     <commons.lang3.version>3.13.0</commons.lang3.version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <spring-boot.version>3.1.6</spring-boot.version>
     <rdf4j.version>4.3.8</rdf4j.version>
     <graphql.java.version>21.3</graphql.java.version>
-    <graphql.java.orchestrate.version>0.2.1-SNAPSHOT</graphql.java.orchestrate.version>
+    <graphql.java.orchestrate.version>0.2.1</graphql.java.orchestrate.version>
     <commons.jexl3.version>3.2.1</commons.jexl3.version>
     <commons.text.version>1.11.0</commons.text.version>
     <commons.lang3.version>3.13.0</commons.lang3.version>

--- a/service/openapi/pom.xml
+++ b/service/openapi/pom.xml
@@ -18,6 +18,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.dotwebstack</groupId>
+      <artifactId>graphql-java-orchestrate</artifactId>
+      <version>${graphql.java.orchestrate.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.dotwebstack.framework</groupId>
       <artifactId>test</artifactId>
       <version>${project.version}</version>

--- a/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/exception/ExceptionRuleHelper.java
+++ b/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/exception/ExceptionRuleHelper.java
@@ -19,6 +19,10 @@ public class ExceptionRuleHelper {
 
   private ExceptionRuleHelper() {}
 
+  private static final String INTERNAL_SERVER_ERROR_MESSAGE = "Internal server error";
+
+  private static final String ERROR_WHILE_PROCESSING_REQUEST_MESSAGE = "Error while processing the request";
+
   public static final List<ExceptionRule> MAPPING = List.of(ExceptionRule.builder()
       .exception(NotAcceptableException.class)
       .responseStatus(NOT_ACCEPTABLE)
@@ -33,12 +37,12 @@ public class ExceptionRuleHelper {
       ExceptionRule.builder()
           .exception(MappingException.class)
           .responseStatus(INTERNAL_SERVER_ERROR)
-          .title("Internal server error")
+          .title(INTERNAL_SERVER_ERROR_MESSAGE)
           .build(),
       ExceptionRule.builder()
           .exception(GraphQlErrorException.class)
           .responseStatus(INTERNAL_SERVER_ERROR)
-          .title("Internal server error")
+          .title(INTERNAL_SERVER_ERROR_MESSAGE)
           .build(),
       ExceptionRule.builder()
           .exception(NoContentException.class)
@@ -58,13 +62,13 @@ public class ExceptionRuleHelper {
       ExceptionRule.builder()
           .exception(BadRequestException.class)
           .responseStatus(BAD_REQUEST)
-          .title("Error while processing the request")
+          .title(ERROR_WHILE_PROCESSING_REQUEST_MESSAGE)
           .detail(true)
           .build(),
       ExceptionRule.builder()
           .exception(RequestValidationException.class)
           .responseStatus(BAD_REQUEST)
-          .title("Error while processing the request")
+          .title(ERROR_WHILE_PROCESSING_REQUEST_MESSAGE)
           .detail(true)
           .build(),
       ExceptionRule.builder()
@@ -80,12 +84,12 @@ public class ExceptionRuleHelper {
       ExceptionRule.builder()
           .exception(GraphqlJavaOrchestrateException.class)
           .responseStatus(INTERNAL_SERVER_ERROR)
-          .title("Internal server error")
+          .title(INTERNAL_SERVER_ERROR_MESSAGE)
           .build(),
       ExceptionRule.builder()
           .exception(GraphqlJavaOrchestrateException.class)
           .responseStatus(BAD_REQUEST)
-          .title("Error while processing the request")
+          .title(ERROR_WHILE_PROCESSING_REQUEST_MESSAGE)
           .detail(true)
           .build());
 
@@ -101,10 +105,11 @@ public class ExceptionRuleHelper {
      * GraphqlJavaOrchestrateException.class can be matched using the HttpStatus.
      */
 
-    if (matchingRules.size() > 1 && throwable instanceof GraphqlJavaOrchestrateException) {
+    if (matchingRules.size() > 1
+        && throwable instanceof GraphqlJavaOrchestrateException graphqlJavaOrchestrateException) {
       return matchingRules.stream()
           .filter(matchingRule -> {
-            var httpStatus = ((GraphqlJavaOrchestrateException) throwable).getStatusCode();
+            var httpStatus = graphqlJavaOrchestrateException.getStatusCode();
             return matchingRule.getResponseStatus()
                 .equals(httpStatus);
           })

--- a/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/handler/OperationHandlerFactory.java
+++ b/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/handler/OperationHandlerFactory.java
@@ -166,9 +166,9 @@ public class OperationHandlerFactory {
 
     if (optionalException.isPresent()) {
       var exception = optionalException.get();
-      if (exception instanceof DelegateException && !((DelegateException) exception).getErrors()
+      if (exception instanceof DelegateException delegateException && !delegateException.getErrors()
           .isEmpty()) {
-        return getExecutionResultMono(executionInput, ((DelegateException) exception).getErrors());
+        return getExecutionResultMono(executionInput, delegateException.getErrors());
       } else {
         return Mono.error(optionalException.get());
       }

--- a/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/handler/OperationHandlerFactory.java
+++ b/service/openapi/src/main/java/org/dotwebstack/framework/service/openapi/handler/OperationHandlerFactory.java
@@ -15,6 +15,7 @@ import graphql.GraphQLError;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.responses.ApiResponse;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -26,6 +27,7 @@ import org.dotwebstack.framework.service.openapi.query.QueryMapper;
 import org.dotwebstack.framework.service.openapi.query.QueryProperties;
 import org.dotwebstack.framework.service.openapi.response.BodyMapper;
 import org.dotwebstack.framework.service.openapi.response.header.ResponseHeaderResolver;
+import org.dotwebstack.graphql.orchestrate.delegate.DelegateException;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.BodyInserters;
@@ -151,11 +153,28 @@ public class OperationHandlerFactory {
         .map("- "::concat)
         .collect(Collectors.joining("\n")));
 
-    return Mono.error(Optional.of(errors.get(0))
+    return getExecutionResultMono(executionInput, errors);
+  }
+
+  private static Mono<ExecutionResult> getExecutionResultMono(ExecutionInput executionInput,
+      List<GraphQLError> errors) {
+
+    var optionalException = Optional.of(errors.get(0))
         .filter(ExceptionWhileDataFetching.class::isInstance)
         .map(ExceptionWhileDataFetching.class::cast)
-        .map(ExceptionWhileDataFetching::getException)
-        .orElse(internalServerErrorException(executionInput)));
+        .map(ExceptionWhileDataFetching::getException);
+
+    if (optionalException.isPresent()) {
+      var exception = optionalException.get();
+      if (exception instanceof DelegateException && !((DelegateException) exception).getErrors()
+          .isEmpty()) {
+        return getExecutionResultMono(executionInput, ((DelegateException) exception).getErrors());
+      } else {
+        return Mono.error(optionalException.get());
+      }
+    }
+
+    return Mono.error(internalServerErrorException(executionInput));
   }
 
   private ContentNegotiator createContentNegotiator(ApiResponse bodyResponse) {

--- a/service/openapi/src/test/java/org/dotwebstack/framework/service/openapi/exception/ExceptionRuleHelperTest.java
+++ b/service/openapi/src/test/java/org/dotwebstack/framework/service/openapi/exception/ExceptionRuleHelperTest.java
@@ -1,0 +1,114 @@
+package org.dotwebstack.framework.service.openapi.exception;
+
+import static org.dotwebstack.framework.service.openapi.exception.ExceptionRuleHelper.getExceptionRule;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_ACCEPTABLE;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
+
+import java.util.stream.Stream;
+import org.dotwebstack.framework.core.InvalidConfigurationException;
+import org.dotwebstack.framework.core.RequestValidationException;
+import org.dotwebstack.framework.core.templating.TemplatingException;
+import org.dotwebstack.framework.service.openapi.mapping.MappingException;
+import org.dotwebstack.graphql.orchestrate.exception.GraphqlJavaOrchestrateException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class ExceptionRuleHelperTest {
+
+
+  @ParameterizedTest
+  @MethodSource("exceptionRules")
+  void getExceptionRule_returnsRule_forException(Exception exception, HttpStatus httpStatus, String title) {
+
+    var result = getExceptionRule(exception);
+
+    assertThat(result.isPresent(), is(true));
+    assertThat(result.get()
+        .getException(), is(exception.getClass()));
+    assertThat(result.get()
+        .getTitle(), is(title));
+    assertThat(result.get()
+        .getResponseStatus(), is(httpStatus));
+  }
+
+  private static Stream<Arguments> exceptionRules() {
+    return Stream.of(
+        Arguments.of(new NotAcceptableException("", new Throwable()), NOT_ACCEPTABLE,
+            "Unsupported media type requested"),
+        Arguments.of(new ParameterValidationException("", new Throwable()), BAD_REQUEST,
+            "Error while obtaining request parameters"),
+        Arguments.of(new MappingException("", new Throwable()), INTERNAL_SERVER_ERROR, "Internal server error"),
+        Arguments.of(new GraphQlErrorException("", new Throwable()), INTERNAL_SERVER_ERROR, "Internal server error"),
+        Arguments.of(new NoContentException("", new Throwable()), NO_CONTENT, "No content"),
+        Arguments.of(new NotFoundException("", new Throwable()), NOT_FOUND, "No results found"),
+        Arguments.of(new UnsupportedOperationException("", new Throwable()), UNSUPPORTED_MEDIA_TYPE, "Not supported"),
+        Arguments.of(new BadRequestException("", new Throwable()), BAD_REQUEST, "Error while processing the request"),
+        Arguments.of(new RequestValidationException("", new Throwable()), BAD_REQUEST,
+            "Error while processing the request"),
+        Arguments.of(new InvalidConfigurationException("", new Throwable()), INTERNAL_SERVER_ERROR,
+            "Bad configuration"),
+        Arguments.of(new TemplatingException("", new Throwable()), INTERNAL_SERVER_ERROR, "Templating went wrong"));
+  }
+
+  @Test
+  void getExceptionRule_returnsEmpty_forNonListedException() {
+    var result = getExceptionRule(new IllegalStateException());
+
+    assertThat(result.isEmpty(), is(true));
+  }
+
+  @Test
+  void getExceptionRule_returnsInternalServerErrorRule_forGraphlqlJavaOrchestrateExceptionWith500status() {
+    var expected = ExceptionRule.builder()
+        .exception(GraphqlJavaOrchestrateException.class)
+        .responseStatus(INTERNAL_SERVER_ERROR)
+        .title("Internal server error")
+        .build();
+
+    var result =
+        getExceptionRule(new GraphqlJavaOrchestrateException(INTERNAL_SERVER_ERROR, "Something went wrong serverside"));
+
+    assertThat(result.isPresent(), is(true));
+    assertThat(result.get()
+        .getException(), is(expected.getException()));
+    assertThat(result.get()
+        .getTitle(), is(expected.getTitle()));
+    assertThat(result.get()
+        .getResponseStatus(), is(expected.getResponseStatus()));
+  }
+
+  @Test
+  void getExceptionRule_returnsInternalServerErrorRule_forGraphlqlJavaOrchestrateExceptionWith400status() {
+    var expected = ExceptionRule.builder()
+        .exception(GraphqlJavaOrchestrateException.class)
+        .responseStatus(BAD_REQUEST)
+        .title("Error while processing the request")
+        .detail(true)
+        .build();
+
+    var result = getExceptionRule(new GraphqlJavaOrchestrateException(BAD_REQUEST, "Bad request"));
+
+    assertThat(result.isPresent(), is(true));
+    assertThat(result.get()
+        .getException(), is(expected.getException()));
+    assertThat(result.get()
+        .getTitle(), is(expected.getTitle()));
+    assertThat(result.get()
+        .getResponseStatus(), is(expected.getResponseStatus()));
+    assertThat(result.get()
+        .isDetail(), is(expected.isDetail()));
+  }
+
+}


### PR DESCRIPTION
Added error handling in the openapi-service for graphql-java-orchestrate exceptions so that the original error details are passed to the user